### PR TITLE
vimc-4221 handle expired orderlyweb tokens

### DIFF
--- a/src/orderlyweb_client_wrapper.py
+++ b/src/orderlyweb_client_wrapper.py
@@ -1,0 +1,28 @@
+import montagu
+import orderlyweb_api
+
+
+def get_authorised_client(config):
+    monty = montagu.MontaguAPI(config.montagu_url, config.montagu_user,
+                               config.montagu_password)
+    ow = orderlyweb_api.OrderlyWebAPI(config.orderlyweb_url,
+                                      monty.token)
+    return ow
+
+
+class OrderlyWebClientWrapper:
+    def __init__(self, config, auth=get_authorised_client):
+        self.config = config
+        self.auth = auth
+        self.ow = auth(config)
+
+    def execute(self, func, *args):
+        try:
+            return func(*args)
+        except Exception as ex:
+            if "expired" in str(ex):
+                self.ow = self.auth(self.config)
+                func = getattr(self.ow, func.__name__)
+                return func(*args)
+            else:
+                raise ex

--- a/src/task_run_diagnostic_reports.py
+++ b/src/task_run_diagnostic_reports.py
@@ -20,10 +20,6 @@ def run_diagnostic_reports(group, disease):
         return []
 
 
-def ow_client(config):
-    return OrderlyWebClientWrapper(config)
-
-
 def run_reports(wrapper, config, reports):
     running_reports = {}
     new_versions = []

--- a/test/integration/test_task_run_diagnostic_reports.py
+++ b/test/integration/test_task_run_diagnostic_reports.py
@@ -1,9 +1,9 @@
 from src.task_run_diagnostic_reports import run_diagnostic_reports, \
-    run_reports, auth
+    run_reports
 from src.config import Config, ReportConfig
 from test.integration.fake_smtp_utils import FakeSmtpUtils, FakeEmailProperties
 import pytest
-
+from src.orderlyweb_client_wrapper import OrderlyWebClientWrapper
 
 smtp = FakeSmtpUtils()
 
@@ -70,7 +70,7 @@ def test_run_reports_handles_error():
         ReportConfig("nonexistent", None, ["test1@test.com"], "subject1"),
         ReportConfig("minimal", {}, ["test2@test.com"], "subject2")]
     config = Config()
-    orderly_web = auth(config)
+    orderly_web = OrderlyWebClientWrapper(config)
     versions = run_reports(orderly_web, config, reports)
     assert len(versions) == 1
 

--- a/test/integration/test_task_run_diagnostic_reports.py
+++ b/test/integration/test_task_run_diagnostic_reports.py
@@ -70,8 +70,8 @@ def test_run_reports_handles_error():
         ReportConfig("nonexistent", None, ["test1@test.com"], "subject1"),
         ReportConfig("minimal", {}, ["test2@test.com"], "subject2")]
     config = Config()
-    orderly_web = OrderlyWebClientWrapper(config)
-    versions = run_reports(orderly_web, config, reports)
+    wrapper = OrderlyWebClientWrapper(config)
+    versions = run_reports(wrapper, config, reports)
     assert len(versions) == 1
 
 

--- a/test/unit/test_orderlyweb_client_wrapper.py
+++ b/test/unit/test_orderlyweb_client_wrapper.py
@@ -1,0 +1,66 @@
+from src.task_run_diagnostic_reports import run_reports
+from src.config import ReportConfig
+from orderlyweb_api import ReportStatusResult
+from unittest.mock import patch, call
+from src.orderlyweb_client_wrapper import OrderlyWebClientWrapper
+from test.unit.test_task_run_diagnostic_reports import MockConfig
+
+reports = [ReportConfig("r1", None, ["r1@example.com"], "Subj: r1")]
+
+send_email_call_r1 = call(
+    "test@test.com", ["r1@example.com"], "Subj: r1", "diagnostic_report",
+    {"report_name": "r1",
+     "report_version_url": "http://orderly-web/report/r1/r1-version/",
+     "report_params": "no parameters"})
+
+report_response = ReportStatusResult({"status": "success",
+                                      "version": "r1-version",
+                                      "output": None})
+
+
+class MockOrderlyWebAPIWithExpiredToken:
+
+    def run_report(self, name, params):
+        raise Exception("Token expired")
+
+    def report_status(self, key):
+        raise Exception("Token expired")
+
+
+class MockOrderlyWebAPIWithValidToken:
+
+    def run_report(self, name, params):
+        return "r1-key"
+
+    def report_status(self, key):
+        return report_response
+
+
+class MockReturnAuthorisedClient:
+    def __init__(self):
+        self.callCount = 0
+
+    def auth(self, config):
+        if self.callCount == 0:
+            self.callCount = 1
+            # if this is the first call, return an expired token error
+            return MockOrderlyWebAPIWithExpiredToken()
+        else:
+            # on the second call, return success reponses
+            return MockOrderlyWebAPIWithValidToken()
+
+
+@patch("src.utils.email.Emailer.send")
+@patch("src.task_run_diagnostic_reports.logging")
+def test_retries_when_token_expired(logging, emailer_send):
+    auth = MockReturnAuthorisedClient().auth
+    wrapper = OrderlyWebClientWrapper(None, auth)
+    versions = run_reports(wrapper, MockConfig(), reports)
+
+    assert versions == ["r1-version"]
+    logging.info.assert_has_calls([
+        call("Running report: r1. Key is r1-key"),
+        call("Success for key r1-key. New version is r1-version")
+    ], any_order=False)
+
+    emailer_send.assert_has_calls([send_email_call_r1])

--- a/test/unit/test_task_run_diagnostic_reports.py
+++ b/test/unit/test_task_run_diagnostic_reports.py
@@ -2,6 +2,7 @@ from src.task_run_diagnostic_reports import run_reports
 from src.config import ReportConfig
 from orderlyweb_api import ReportStatusResult
 from unittest.mock import patch, call
+from src.orderlyweb_client_wrapper import OrderlyWebClientWrapper
 
 reports = [ReportConfig("r1", None, ["r1@example.com"], "Subj: r1"),
            ReportConfig("r2", {"p1": "v1"}, ["r2@example.com"], "Subj: r2")]
@@ -32,8 +33,8 @@ def test_run_reports(logging, emailer_send):
                                        "output": None})]
     }
     ow = MockOrderlyWebAPI(run_successfully, report_responses)
-
-    versions = run_reports(ow, MockConfig(), reports)
+    wrapper = OrderlyWebClientWrapper(None, lambda x: ow)
+    versions = run_reports(wrapper, MockConfig(), reports)
 
     assert versions == ["r1-version", "r2-version"]
 
@@ -67,8 +68,8 @@ def test_run_reports_finish_on_different_poll_cycles(logging, emailer_send):
                                        "output": None})]
     }
     ow = MockOrderlyWebAPI(run_successfully, report_responses)
-
-    versions = run_reports(ow, MockConfig(), reports)
+    wrapper = OrderlyWebClientWrapper(None, lambda x: ow)
+    versions = run_reports(wrapper, MockConfig(), reports)
 
     assert versions == ["r2-version", "r1-version"]
 
@@ -92,8 +93,8 @@ def test_run_reports_with_run_error(logging, emailer_send):
                                       "output": None})]
     }
     ow = MockOrderlyWebAPI(run_successfully, report_responses)
-
-    versions = run_reports(ow, MockConfig(), reports)
+    wrapper = OrderlyWebClientWrapper(None, lambda x: ow)
+    versions = run_reports(wrapper, MockConfig(), reports)
 
     assert versions == ["r2-version"]
     logging.info.assert_has_calls([
@@ -117,8 +118,8 @@ def test_run_reports_with_status_error(logging, emailer_send):
     }
 
     ow = MockOrderlyWebAPI(run_successfully, report_responses)
-
-    versions = run_reports(ow, MockConfig(), reports)
+    wrapper = OrderlyWebClientWrapper(None, lambda x: ow)
+    versions = run_reports(wrapper, MockConfig(), reports)
 
     assert versions == ["r2-version"]
     logging.info.assert_has_calls([
@@ -146,8 +147,8 @@ def test_run_reports_with_status_failure(logging, emailer_send):
     }
 
     ow = MockOrderlyWebAPI(run_successfully, report_responses)
-
-    versions = run_reports(ow, MockConfig(), reports)
+    wrapper = OrderlyWebClientWrapper(None, lambda x: ow)
+    versions = run_reports(wrapper, MockConfig(), reports)
 
     assert versions == ["r1-version"]
     logging.info.assert_has_calls([
@@ -175,8 +176,8 @@ def test_url_encodes_url_in_email(emailer_send):
                                           "output": None})]
     }
     ow = MockOrderlyWebAPI(run_successfully, report_responses)
-
-    run_reports(ow, MockConfig(), [report])
+    wrapper = OrderlyWebClientWrapper(None, lambda x: ow)
+    run_reports(wrapper, MockConfig(), [report])
     url = "http://orderly-web/report/{}/{}-version/".format(encoded, encoded)
     emailer_send.assert_has_calls([
         call("test@test.com", ["to@example.com"], "Hi", "diagnostic_report",


### PR DESCRIPTION
This PR adds a class that wraps the orderlyweb api client and automatically refreshes the token and retries the api call if a call fails with an expired token message. It would be nice to pull out expiry/retry logic into the orderly-web-py client itself, but that would require a bigger refactor, possibly introducing refresh tokens in orderlyweb. Something to look at longer term.