### PR TITLE
vimc-4220 publish new diagnostic reports 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ celery
 future
 pyyaml
 montagu>=0.0.2
-orderlyweb-api>=0.0.6
+orderlyweb-api>=0.0.7

--- a/scripts/run-dependencies.sh
+++ b/scripts/run-dependencies.sh
@@ -38,4 +38,4 @@ $here/montagu_cli.sh addRole test.user user
 
 # Add user to orderlyweb
 $here/orderlyweb_cli.sh add-users test.user@example.com
-$here/orderlyweb_cli.sh grant test.user@example.com */reports.run
+$here/orderlyweb_cli.sh grant test.user@example.com */reports.read */reports.run */reports.review

--- a/src/task_run_diagnostic_reports.py
+++ b/src/task_run_diagnostic_reports.py
@@ -31,7 +31,7 @@ def publish_report(wrapper, name, version):
 
 def run_reports(wrapper, config, reports):
     running_reports = {}
-    new_versions = []
+    new_versions = {}
     emailer = Emailer(config.smtp_host, config.smtp_port)
 
     # Start configured reports
@@ -59,19 +59,24 @@ def run_reports(wrapper, config, reports):
                 if result.finished:
                     finished.append(key)
                     if result.success:
-                        new_versions.append(result.version)
                         logging.info("Success for key {}. New version is {}"
                                      .format(key, result.version))
                         version = result.version
                         name = report.name
-                        if publish_report(wrapper, name, version):
+                        published = publish_report(wrapper, name, version)
+                        if published:
+                            logging.info(
+                                "Successfully published report version {}-{}"
+                                    .format(name, version))
                             send_success_email(emailer,
                                                report,
                                                version,
                                                config)
                         else:
-                            logging.error("Failed to publish report {}-{}"
-                                          .format(name, version))
+                            logging.error(
+                                "Failed to publish report version {}-{}"
+                                    .format(name, version))
+                        new_versions[version] = {"published": published}
                     else:
                         logging.error("Failure for key {}.".format(key))
 

--- a/src/task_run_diagnostic_reports.py
+++ b/src/task_run_diagnostic_reports.py
@@ -28,6 +28,15 @@ def auth(config):
     return ow
 
 
+def publish_report(orderly_web, name, version):
+    try:
+        logging.info("Publishing report version {}-{}".format(name, version))
+        return orderly_web.publish_report(name, version)
+    except Exception as ex:
+        logging.exception(ex)
+        return False
+
+
 def run_reports(orderly_web, config, reports):
     running_reports = {}
     new_versions = []
@@ -58,9 +67,16 @@ def run_reports(orderly_web, config, reports):
                         new_versions.append(result.version)
                         logging.info("Success for key {}. New version is {}"
                                      .format(key, result.version))
-
-                        send_success_email(emailer, report, result.version,
-                                           config)
+                        version = result.version
+                        name = report.name
+                        if publish_report(orderly_web, name, version):
+                            send_success_email(emailer,
+                                               report,
+                                               version,
+                                               config)
+                        else:
+                            logging.error("Failed to publish report {}-{}"
+                                          .format(name, version))
                     else:
                         logging.error("Failure for key {}.".format(key))
 

--- a/src/task_run_diagnostic_reports.py
+++ b/src/task_run_diagnostic_reports.py
@@ -67,7 +67,7 @@ def run_reports(wrapper, config, reports):
                         if published:
                             logging.info(
                                 "Successfully published report version {}-{}"
-                                    .format(name, version))
+                                .format(name, version))
                             send_success_email(emailer,
                                                report,
                                                version,
@@ -75,7 +75,7 @@ def run_reports(wrapper, config, reports):
                         else:
                             logging.error(
                                 "Failed to publish report version {}-{}"
-                                    .format(name, version))
+                                .format(name, version))
                         new_versions[version] = {"published": published}
                     else:
                         logging.error("Failure for key {}.".format(key))

--- a/test/integration/test_task_run_diagnostic_reports.py
+++ b/test/integration/test_task_run_diagnostic_reports.py
@@ -14,7 +14,7 @@ def mod_header(request):
 
 
 def test_run_diagnostic_reports():
-    versions = run_diagnostic_reports("testGroup", "testDisease")
+    versions = list(run_diagnostic_reports("testGroup", "testDisease").keys())
     assert len(versions) == 2
 
     expected_text = """Hi
@@ -72,7 +72,9 @@ def test_run_reports_handles_error():
     config = Config()
     wrapper = OrderlyWebClientWrapper(config)
     versions = run_reports(wrapper, config, reports)
-    assert len(versions) == 1
+    keys = list(versions.keys())
+    assert len(keys) == 1
+    assert versions[keys[0]]["published"] is True
 
 
 def test_run_reports_no_group_config():

--- a/test/unit/test_orderlyweb_client_wrapper.py
+++ b/test/unit/test_orderlyweb_client_wrapper.py
@@ -63,10 +63,12 @@ def test_retries_when_token_expired(logging, emailer_send):
     wrapper = OrderlyWebClientWrapper(None, auth)
     versions = run_reports(wrapper, MockConfig(), reports)
 
-    assert versions == ["r1-version"]
+    assert versions == {"r1-version": {"published": True}}
     logging.info.assert_has_calls([
         call("Running report: r1. Key is r1-key"),
-        call("Success for key r1-key. New version is r1-version")
+        call("Success for key r1-key. New version is r1-version"),
+        call("Publishing report version r1-r1-version"),
+        call("Successfully published report version r1-r1-version")
     ], any_order=False)
 
     emailer_send.assert_has_calls([send_email_call_r1])

--- a/test/unit/test_task_run_diagnostic_reports.py
+++ b/test/unit/test_task_run_diagnostic_reports.py
@@ -36,15 +36,20 @@ def test_run_reports(logging, emailer_send):
     wrapper = OrderlyWebClientWrapper(None, lambda x: ow)
     versions = run_reports(wrapper, MockConfig(), reports)
 
-    assert versions == ["r1-version", "r2-version"]
+    assert versions == {
+        "r1-version": {"published": True},
+        "r2-version": {"published": True}
+    }
 
     logging.info.assert_has_calls([
         call("Running report: r1. Key is r1-key"),
         call("Running report: r2. Key is r2-key"),
         call("Success for key r1-key. New version is r1-version"),
         call("Publishing report version r1-r1-version"),
+        call("Successfully published report version r1-r1-version"),
         call("Success for key r2-key. New version is r2-version"),
-        call("Publishing report version r2-r2-version")
+        call("Publishing report version r2-r2-version"),
+        call("Successfully published report version r2-r2-version")
     ], any_order=False)
 
     emailer_send.assert_has_calls([send_email_call_r1, send_email_call_r2])
@@ -73,15 +78,20 @@ def test_run_reports_finish_on_different_poll_cycles(logging, emailer_send):
     wrapper = OrderlyWebClientWrapper(None, lambda x: ow)
     versions = run_reports(wrapper, MockConfig(), reports)
 
-    assert versions == ["r2-version", "r1-version"]
+    assert versions == {
+        "r2-version": {"published": True},
+        "r1-version": {"published": True}
+    }
 
     logging.info.assert_has_calls([
         call("Running report: r1. Key is r1-key"),
         call("Running report: r2. Key is r2-key"),
         call("Success for key r2-key. New version is r2-version"),
         call("Publishing report version r2-r2-version"),
+        call("Successfully published report version r2-r2-version"),
         call("Success for key r1-key. New version is r1-version"),
-        call("Publishing report version r1-r1-version")
+        call("Publishing report version r1-r1-version"),
+        call("Successfully published report version r1-r1-version")
     ], any_order=False)
 
     emailer_send.assert_has_calls([send_email_call_r2, send_email_call_r1])
@@ -92,19 +102,23 @@ def test_run_reports_finish_on_different_poll_cycles(logging, emailer_send):
 def test_run_reports_with_run_error(logging, emailer_send):
     run_successfully = ["r2"]
     report_responses = {
-       "r2-key": [ReportStatusResult({"status": "success",
-                                      "version": "r2-version",
-                                      "output": None})]
+        "r2-key": [ReportStatusResult({"status": "success",
+                                       "version": "r2-version",
+                                       "output": None})]
     }
     ow = MockOrderlyWebAPI(run_successfully, report_responses)
     wrapper = OrderlyWebClientWrapper(None, lambda x: ow)
     versions = run_reports(wrapper, MockConfig(), reports)
 
-    assert versions == ["r2-version"]
+    assert versions == {
+        "r2-version": {"published": True}
+    }
+
     logging.info.assert_has_calls([
         call("Running report: r2. Key is r2-key"),
         call("Success for key r2-key. New version is r2-version"),
-        call("Publishing report version r2-r2-version")
+        call("Publishing report version r2-r2-version"),
+        call("Successfully published report version r2-r2-version")
     ], any_order=False)
     args, kwargs = logging.exception.call_args
     assert str(args[0]) == "test-run-error: r1"
@@ -126,12 +140,16 @@ def test_run_reports_with_status_error(logging, emailer_send):
     wrapper = OrderlyWebClientWrapper(None, lambda x: ow)
     versions = run_reports(wrapper, MockConfig(), reports)
 
-    assert versions == ["r2-version"]
+    assert versions == {
+        "r2-version": {"published": True}
+    }
+
     logging.info.assert_has_calls([
         call("Running report: r1. Key is r1-key"),
         call("Running report: r2. Key is r2-key"),
         call("Success for key r2-key. New version is r2-version"),
-        call("Publishing report version r2-r2-version")
+        call("Publishing report version r2-r2-version"),
+        call("Successfully published report version r2-r2-version")
     ], any_order=False)
     args, kwargs = logging.exception.call_args
     assert str(args[0]) == "test-status-error: r1-key"
@@ -156,15 +174,57 @@ def test_run_reports_with_status_failure(logging, emailer_send):
     wrapper = OrderlyWebClientWrapper(None, lambda x: ow)
     versions = run_reports(wrapper, MockConfig(), reports)
 
-    assert versions == ["r1-version"]
+    assert versions == {
+        "r1-version": {"published": True}
+    }
+
     logging.info.assert_has_calls([
         call("Running report: r1. Key is r1-key"),
         call("Running report: r2. Key is r2-key"),
         call("Success for key r1-key. New version is r1-version"),
-        call("Publishing report version r1-r1-version")
+        call("Publishing report version r1-r1-version"),
+        call("Successfully published report version r1-r1-version")
     ], any_order=False)
     logging.error.assert_has_calls([
-       call("Failure for key r2-key.")
+        call("Failure for key r2-key.")
+    ], any_order=False)
+
+    emailer_send.assert_has_calls([send_email_call_r1])
+
+
+@patch("src.utils.email.Emailer.send")
+@patch("src.task_run_diagnostic_reports.logging")
+def test_run_reports_with_publish_failure(logging, emailer_send):
+    run_successfully = ["r1", "r2"]
+    report_responses = {
+        "r1-key": [ReportStatusResult({"status": "success",
+                                       "version": "r1-version",
+                                       "output": None})],
+        "r2-key": [ReportStatusResult({"status": "success",
+                                       "version": "r2-version",
+                                       "output": None})]
+    }
+    fail_publish = ["r2"]
+    ow = MockOrderlyWebAPI(run_successfully, report_responses, fail_publish)
+    wrapper = OrderlyWebClientWrapper(None, lambda x: ow)
+    versions = run_reports(wrapper, MockConfig(), reports)
+
+    assert versions == {
+        "r1-version": {"published": True},
+        "r2-version": {"published": False}
+    }
+
+    logging.info.assert_has_calls([
+        call("Running report: r1. Key is r1-key"),
+        call("Running report: r2. Key is r2-key"),
+        call("Success for key r1-key. New version is r1-version"),
+        call("Publishing report version r1-r1-version"),
+        call("Successfully published report version r1-r1-version"),
+        call("Success for key r2-key. New version is r2-version"),
+        call("Publishing report version r2-r2-version")
+    ], any_order=False)
+    logging.error.assert_has_calls([
+        call("Failed to publish report version r2-r2-version")
     ], any_order=False)
 
     emailer_send.assert_has_calls([send_email_call_r1])
@@ -178,9 +238,9 @@ def test_url_encodes_url_in_email(emailer_send):
 
     run_successfully = [name]
     report_responses = {
-        name+"-key": [ReportStatusResult({"status": "success",
-                                          "version": name+"-version",
-                                          "output": None})]
+        name + "-key": [ReportStatusResult({"status": "success",
+                                            "version": name + "-version",
+                                            "output": None})]
     }
     ow = MockOrderlyWebAPI(run_successfully, report_responses)
     wrapper = OrderlyWebClientWrapper(None, lambda x: ow)
@@ -194,9 +254,12 @@ def test_url_encodes_url_in_email(emailer_send):
 
 
 class MockOrderlyWebAPI:
-    def __init__(self, run_successfully, report_responses):
+    def __init__(self, run_successfully, report_responses, fail_publish=None):
+        if fail_publish is None:
+            fail_publish = []
         self.run_successfully = run_successfully
         self.report_responses = report_responses
+        self.fail_publish = fail_publish
 
     def run_report(self, name, params):
         if name in self.run_successfully:
@@ -212,7 +275,10 @@ class MockOrderlyWebAPI:
             raise Exception("test-status-error: " + key)
 
     def publish_report(self, name, version):
-        return True
+        if name in self.fail_publish:
+            raise Exception("Publish failed")
+        else:
+            return True
 
 
 class MockConfig:


### PR DESCRIPTION
This PR makes sure that new report versions are published before emailing the recipients. 

Possibly fine-tuning for a future ticket - perhaps would want to still email internal recipients (the VIMC Science team) if the report runs successfully but fails to be published since it could then still be manually published and emailed out. But this is an edge case since there's no reason for publishing to fail if running has passed (only real reason I can think of is if the task q user's permissions become corrupted since the 2 endpoints require different perms.)