### PR TITLE
vimc-4222 Add parameter to task for additional email recipients

### DIFF
--- a/scripts/clear-docker.sh
+++ b/scripts/clear-docker.sh
@@ -1,3 +1,4 @@
 docker stop $(docker ps -aq)
 docker rm $(docker ps -aq)
 docker network prune --force
+docker volume prune --force

--- a/src/task_run_diagnostic_reports.py
+++ b/src/task_run_diagnostic_reports.py
@@ -20,7 +20,7 @@ def run_diagnostic_reports(group, disease, additional_recipients=None):
         return []
 
 
-def run_reports(wrapper, config, reports, additional_recipients=None):
+def run_reports(wrapper, config, reports, *additional_recipients):
     running_reports = {}
     new_versions = []
     emailer = Emailer(config.smtp_host, config.smtp_port)
@@ -91,10 +91,7 @@ def send_success_email(emailer, report, version, config,
         "report_params": report_params
     }
 
-    if additional_recipients is None:
-        recipients = report.success_email_recipients
-    else:
-        recipients = report.success_email_recipients + additional_recipients
+    recipients = report.success_email_recipients + list(additional_recipients)
 
     emailer.send(config.smtp_from, recipients,
                  report.success_email_subject, "diagnostic_report",

--- a/src/task_run_diagnostic_reports.py
+++ b/src/task_run_diagnostic_reports.py
@@ -17,7 +17,7 @@ def run_diagnostic_reports(group, disease, additional_recipients=None):
     else:
         msg = "No configured diagnostic reports for group {}, disease {}"
         logging.warning(msg.format(group, disease))
-        return []
+        return {}
 
 
 def publish_report(wrapper, name, version):
@@ -115,7 +115,8 @@ def send_success_email(emailer, report, version, config,
         "report_params": report_params
     }
 
-    recipients = report.success_email_recipients + list(additional_recipients)
+    additional_str = filter(lambda arg: arg is not None, additional_recipients)
+    recipients = report.success_email_recipients + list(additional_str)
 
     emailer.send(config.smtp_from, recipients,
                  report.success_email_subject, "diagnostic_report",

--- a/src/task_run_diagnostic_reports.py
+++ b/src/task_run_diagnostic_reports.py
@@ -71,7 +71,8 @@ def run_reports(wrapper, config, reports, additional_recipients=None):
     return new_versions
 
 
-def send_success_email(emailer, report, version, config, additional_recipients):
+def send_success_email(emailer, report, version, config,
+                       additional_recipients):
     r_enc = urlencode(report.name)
     v_enc = urlencode(version)
     version_url = "{}/report/{}/{}/".format(config.orderlyweb_url, r_enc,

--- a/src/task_run_diagnostic_reports.py
+++ b/src/task_run_diagnostic_reports.py
@@ -8,12 +8,12 @@ from src.orderlyweb_client_wrapper import OrderlyWebClientWrapper
 
 
 @app.task
-def run_diagnostic_reports(group, disease, additional_recipients=None):
+def run_diagnostic_reports(group, disease, *additional_recipients):
     config = Config()
     reports = config.diagnostic_reports(group, disease)
     if len(reports) > 0:
         wrapper = OrderlyWebClientWrapper(config)
-        return run_reports(wrapper, config, reports, additional_recipients)
+        return run_reports(wrapper, config, reports, *additional_recipients)
     else:
         msg = "No configured diagnostic reports for group {}, disease {}"
         logging.warning(msg.format(group, disease))
@@ -115,8 +115,7 @@ def send_success_email(emailer, report, version, config,
         "report_params": report_params
     }
 
-    additional_str = filter(lambda arg: arg is not None, additional_recipients)
-    recipients = report.success_email_recipients + list(additional_str)
+    recipients = report.success_email_recipients + list(additional_recipients)
 
     emailer.send(config.smtp_from, recipients,
                  report.success_email_subject, "diagnostic_report",

--- a/test/integration/test_task_run_diagnostic_reports.py
+++ b/test/integration/test_task_run_diagnostic_reports.py
@@ -16,7 +16,8 @@ def mod_header(request):
 def test_run_diagnostic_reports():
     result = run_diagnostic_reports("testGroup",
                                     "testDisease",
-                                    "estimate_uploader@example.com")
+                                    "estimate_uploader@example.com",
+                                    "estimate_uploader2@example.com")
     versions = list(result.keys())
     assert len(versions) == 2
 
@@ -56,14 +57,16 @@ Have a great day!"""
         FakeEmailProperties(
             "New version of Orderly report: minimal",
             ["minimal_modeller@example.com", "science@example.com",
-             "estimate_uploader@example.com"],
+             "estimate_uploader@example.com",
+             "estimate_uploader2@example.com"],
             "noreply@example.com",
             expected_text.format(report_1, url_1, params_1),
             expected_html.format(report_1, url_1, params_1)),
         FakeEmailProperties(
             "New version of another Orderly report: other",
             ["other_modeller@example.com", "science@example.com",
-             "estimate_uploader@example.com"],
+             "estimate_uploader@example.com",
+             "estimate_uploader2@example.com"],
             "noreply@example.com",
             expected_text.format(report_2, url_2, params_2),
             expected_html.format(report_2, url_2, params_2))

--- a/test/integration/test_task_run_diagnostic_reports.py
+++ b/test/integration/test_task_run_diagnostic_reports.py
@@ -15,7 +15,7 @@ def mod_header(request):
 
 def test_run_diagnostic_reports():
     versions = run_diagnostic_reports("testGroup", "testDisease",
-                                      ["estimate_uploader@example.com"])
+                                      "estimate_uploader@example.com")
     assert len(versions) == 2
 
     expected_text = """Hi

--- a/test/integration/test_task_run_diagnostic_reports.py
+++ b/test/integration/test_task_run_diagnostic_reports.py
@@ -17,7 +17,7 @@ def test_run_diagnostic_reports():
     result = run_diagnostic_reports("testGroup",
                                     "testDisease",
                                     "estimate_uploader@example.com")
-    versions = result.keys()
+    versions = list(result.keys())
     assert len(versions) == 2
 
     expected_text = """Hi

--- a/test/integration/test_task_run_diagnostic_reports.py
+++ b/test/integration/test_task_run_diagnostic_reports.py
@@ -14,7 +14,7 @@ def mod_header(request):
 
 
 def test_run_diagnostic_reports():
-    versions = run_diagnostic_reports("testGroup", "testDisease")
+    versions = run_diagnostic_reports("testGroup", "testDisease", ["estimate_uploader@example.com"])
     assert len(versions) == 2
 
     expected_text = """Hi
@@ -52,13 +52,13 @@ Have a great day!"""
     smtp.assert_emails_match([
         FakeEmailProperties(
             "New version of Orderly report: minimal",
-            ["minimal_modeller@example.com", "science@example.com"],
+            ["minimal_modeller@example.com", "science@example.com", "estimate_uploader@example.com"],
             "noreply@example.com",
             expected_text.format(report_1, url_1, params_1),
             expected_html.format(report_1, url_1, params_1)),
         FakeEmailProperties(
             "New version of another Orderly report: other",
-            ["other_modeller@example.com", "science@example.com"],
+            ["other_modeller@example.com", "science@example.com", "estimate_uploader@example.com"],
             "noreply@example.com",
             expected_text.format(report_2, url_2, params_2),
             expected_html.format(report_2, url_2, params_2))

--- a/test/integration/test_task_run_diagnostic_reports.py
+++ b/test/integration/test_task_run_diagnostic_reports.py
@@ -14,8 +14,10 @@ def mod_header(request):
 
 
 def test_run_diagnostic_reports():
-    versions = list(run_diagnostic_reports("testGroup", "testDisease",
-                                      "estimate_uploader@example.com").keys())
+    result = run_diagnostic_reports("testGroup",
+                                    "testDisease",
+                                    "estimate_uploader@example.com")
+    versions = result.keys()
     assert len(versions) == 2
 
     expected_text = """Hi

--- a/test/integration/test_task_run_diagnostic_reports.py
+++ b/test/integration/test_task_run_diagnostic_reports.py
@@ -14,7 +14,8 @@ def mod_header(request):
 
 
 def test_run_diagnostic_reports():
-    versions = run_diagnostic_reports("testGroup", "testDisease", ["estimate_uploader@example.com"])
+    versions = run_diagnostic_reports("testGroup", "testDisease",
+                                      ["estimate_uploader@example.com"])
     assert len(versions) == 2
 
     expected_text = """Hi
@@ -52,13 +53,15 @@ Have a great day!"""
     smtp.assert_emails_match([
         FakeEmailProperties(
             "New version of Orderly report: minimal",
-            ["minimal_modeller@example.com", "science@example.com", "estimate_uploader@example.com"],
+            ["minimal_modeller@example.com", "science@example.com",
+             "estimate_uploader@example.com"],
             "noreply@example.com",
             expected_text.format(report_1, url_1, params_1),
             expected_html.format(report_1, url_1, params_1)),
         FakeEmailProperties(
             "New version of another Orderly report: other",
-            ["other_modeller@example.com", "science@example.com", "estimate_uploader@example.com"],
+            ["other_modeller@example.com", "science@example.com",
+             "estimate_uploader@example.com"],
             "noreply@example.com",
             expected_text.format(report_2, url_2, params_2),
             expected_html.format(report_2, url_2, params_2))

--- a/test/unit/test_task_run_diagnostic_reports.py
+++ b/test/unit/test_task_run_diagnostic_reports.py
@@ -62,7 +62,8 @@ def test_run_reports_with_additional_recipients(logging, emailer_send):
     }
     ow = MockOrderlyWebAPI(run_successfully, report_responses)
     wrapper = OrderlyWebClientWrapper(None, lambda x: ow)
-    versions = run_reports(wrapper, MockConfig(), reports, ["another@recipient.com"])
+    versions = run_reports(wrapper, MockConfig(), reports,
+                           ["another@recipient.com"])
 
     assert versions == ["r1-version", "r2-version"]
 
@@ -74,18 +75,21 @@ def test_run_reports_with_additional_recipients(logging, emailer_send):
     ], any_order=False)
 
     send_email_call_r1_additional = call(
-        "test@test.com", ["r1@example.com", "another@recipient.com"], "Subj: r1", "diagnostic_report",
+        "test@test.com", ["r1@example.com", "another@recipient.com"],
+        "Subj: r1", "diagnostic_report",
         {"report_name": "r1",
          "report_version_url": "http://orderly-web/report/r1/r1-version/",
          "report_params": "no parameters"})
 
     send_email_call_r2_additional = call(
-        "test@test.com", ["r2@example.com", "another@recipient.com"], "Subj: r2", "diagnostic_report",
+        "test@test.com", ["r2@example.com", "another@recipient.com"],
+        "Subj: r2", "diagnostic_report",
         {"report_name": "r2",
          "report_version_url": "http://orderly-web/report/r2/r2-version/",
          "report_params": "p1=v1"})
 
-    emailer_send.assert_has_calls([send_email_call_r1_additional, send_email_call_r2_additional])
+    emailer_send.assert_has_calls([send_email_call_r1_additional,
+                                   send_email_call_r2_additional])
 
 
 @patch("src.utils.email.Emailer.send")

--- a/test/unit/test_task_run_diagnostic_reports.py
+++ b/test/unit/test_task_run_diagnostic_reports.py
@@ -63,7 +63,7 @@ def test_run_reports_with_additional_recipients(logging, emailer_send):
     ow = MockOrderlyWebAPI(run_successfully, report_responses)
     wrapper = OrderlyWebClientWrapper(None, lambda x: ow)
     versions = run_reports(wrapper, MockConfig(), reports,
-                           ["another@recipient.com"])
+                           "another@recipient.com")
 
     assert versions == ["r1-version", "r2-version"]
 

--- a/test/unit/test_task_run_diagnostic_reports.py
+++ b/test/unit/test_task_run_diagnostic_reports.py
@@ -72,13 +72,20 @@ def test_run_reports_with_additional_recipients(logging, emailer_send):
     versions = run_reports(wrapper, MockConfig(), reports,
                            "another@recipient.com")
 
-    assert versions == ["r1-version", "r2-version"]
+    assert versions == {
+        "r1-version": {"published": True},
+        "r2-version": {"published": True}
+    }
 
     logging.info.assert_has_calls([
         call("Running report: r1. Key is r1-key"),
         call("Running report: r2. Key is r2-key"),
         call("Success for key r1-key. New version is r1-version"),
-        call("Success for key r2-key. New version is r2-version")
+        call("Publishing report version r1-r1-version"),
+        call("Successfully published report version r1-r1-version"),
+        call("Success for key r2-key. New version is r2-version"),
+        call("Publishing report version r2-r2-version"),
+        call("Successfully published report version r2-r2-version")
     ], any_order=False)
 
     send_email_call_r1_additional = call(


### PR DESCRIPTION
This will be used by the API to pass the email address of the burden estimate uploader. 