### PR TITLE
vimc-4223 Support smtp user and password

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -10,6 +10,8 @@ servers:
   smtp:
     host: localhost
     port: 1025
+    user:
+    password:
     from: noreply@example.com
 tasks:
   diagnostic_reports:

--- a/src/config.py
+++ b/src/config.py
@@ -55,6 +55,14 @@ class Config:
     def smtp_from(self):
         return self.__smtp()["from"]
 
+    @property
+    def smtp_user(self):
+        return self.__value_or_default(self.__smtp(), "user", None)
+
+    @property
+    def smtp_password(self):
+        return self.__value_or_default(self.__smtp(), "password", None)
+
     def diagnostic_reports(self, group, disease):
         result = []
         reports_config = self.__task("diagnostic_reports")["reports"]

--- a/src/task_run_diagnostic_reports.py
+++ b/src/task_run_diagnostic_reports.py
@@ -23,7 +23,8 @@ def run_diagnostic_reports(group, disease):
 def run_reports(wrapper, config, reports):
     running_reports = {}
     new_versions = []
-    emailer = Emailer(config.smtp_host, config.smtp_port)
+    emailer = Emailer(config.smtp_host, config.smtp_port,
+                      config.smtp_user, config.smtp_password)
 
     # Start configured reports
     for report in reports:

--- a/src/utils/email.py
+++ b/src/utils/email.py
@@ -6,9 +6,11 @@ from email.mime.text import MIMEText
 
 class Emailer:
 
-    def __init__(self, smtp_host, smtp_port):
+    def __init__(self, smtp_host, smtp_port, smtp_user, smtp_password):
         self.smtp_host = smtp_host
         self.smtp_port = smtp_port
+        self.smtp_user = smtp_user
+        self.smtp_password = smtp_password
 
     def send(self, from_email, to_emails, subject_template,
              content_template_name, template_values):
@@ -31,6 +33,9 @@ class Emailer:
         msg.attach(part2)
 
         smtp = smtplib.SMTP(self.smtp_host, self.smtp_port)
+        smtp.starttls()
+        if self.smtp_user is not None and self.smtp_password is not None:
+            smtp.login(self.smtp_user, self.smtp_password)
         smtp.sendmail(from_email, to_emails, msg.as_string())
         smtp.quit()
         logging.info("Successfully sent email")

--- a/test/integration/test_config.py
+++ b/test/integration/test_config.py
@@ -43,6 +43,14 @@ def test_smtp_from():
     assert config.smtp_from == "noreply@example.com"
 
 
+def test_smtp_user():
+    assert config.smtp_user is None
+
+
+def test_smtp_password():
+    assert config.smtp_password is None
+
+
 def test_diagnostic_reports():
     reports = config.diagnostic_reports("testGroup", "testDisease")
     assert len(reports) == 2

--- a/test/integration/test_email.py
+++ b/test/integration/test_email.py
@@ -12,7 +12,7 @@ def mod_header(request):
 
 
 def test_send():
-    emailer = Emailer("localhost", 1025)
+    emailer = Emailer("localhost", 1025, None, None)
     emailer.send("from@example.com",
                  ["to1@example.com", "to2@example.com"],
                  "New version of Orderly report: {report_name}",

--- a/test/unit/test_email.py
+++ b/test/unit/test_email.py
@@ -1,0 +1,30 @@
+from unittest.mock import patch, call
+from src.utils.email import Emailer
+
+
+@patch("smtplib.SMTP")
+def test_send_with_login(smtp):
+    emailer = Emailer("remote.host", 1000, "username", "password")
+    emailer.send("from@example.com",
+                 ["to1@example.com"],
+                 "New version of Orderly report: {report_name}",
+                 "diagnostic_report",
+                 {"report_name": "TEST REPORT",
+                  "report_version_url": "http://test.com/test_report_version",
+                  "report_params": "p1=v1, p2=v2"})
+    smtp.return_value.login.assert_has_calls([
+        call("username", "password"),
+    ])
+
+
+@patch("smtplib.SMTP")
+def test_send_without_login(smtp):
+    emailer = Emailer("remote.host", 1000, None, None)
+    emailer.send("from@example.com",
+                 ["to1@example.com"],
+                 "New version of Orderly report: {report_name}",
+                 "diagnostic_report",
+                 {"report_name": "TEST REPORT",
+                  "report_version_url": "http://test.com/test_report_version",
+                  "report_params": "p1=v1, p2=v2"})
+    smtp.return_value.login.assert_not_called()

--- a/test/unit/test_task_run_diagnostic_reports.py
+++ b/test/unit/test_task_run_diagnostic_reports.py
@@ -223,5 +223,13 @@ class MockConfig:
         return "test@test.com"
 
     @property
+    def smtp_user(self):
+        return None
+
+    @property
+    def smtp_password(self):
+        return None
+
+    @property
     def orderlyweb_url(self):
         return "http://orderly-web"


### PR DESCRIPTION
So that we can send real emails on the production server. This is a bit tricky to test since it will only be used on production, but I've tested locally by mangling the config.yml as follows:
```
smtp:
    host: smtp.cc.ic.ac.uk
    port: 587
    user: montagu
    password: [secret from vault email/password]
    from: montagu-notifications@imperial.ac.uk
```
and setting myself as the email recipient for the configured reports, then running the tests. Emails were received successfully.