### PR TITLE
vimc-4257 handle errors

### DIFF
--- a/src/orderlyweb_client_wrapper.py
+++ b/src/orderlyweb_client_wrapper.py
@@ -6,9 +6,9 @@ import logging
 def get_authorised_client(config):
     try:
         monty = montagu.MontaguAPI(config.montagu_url, config.montagu_user,
-                               config.montagu_password)
+                                   config.montagu_password)
         ow = orderlyweb_api.OrderlyWebAPI(config.orderlyweb_url,
-                                      monty.token)
+                                          monty.token)
         return ow
     except Exception as ex:
         logging.exception(ex)

--- a/src/orderlyweb_client_wrapper.py
+++ b/src/orderlyweb_client_wrapper.py
@@ -1,13 +1,18 @@
 import montagu
 import orderlyweb_api
+import logging
 
 
 def get_authorised_client(config):
-    monty = montagu.MontaguAPI(config.montagu_url, config.montagu_user,
+    try:
+        monty = montagu.MontaguAPI(config.montagu_url, config.montagu_user,
                                config.montagu_password)
-    ow = orderlyweb_api.OrderlyWebAPI(config.orderlyweb_url,
+        ow = orderlyweb_api.OrderlyWebAPI(config.orderlyweb_url,
                                       monty.token)
-    return ow
+        return ow
+    except Exception as ex:
+        logging.exception(ex)
+        return None
 
 
 class OrderlyWebClientWrapper:

--- a/src/utils/email.py
+++ b/src/utils/email.py
@@ -56,8 +56,10 @@ def send_email(emailer,
                template_values,
                config,
                additional_recipients):
-
-    recipients = report.success_email_recipients + additional_recipients
-    emailer.send(config.smtp_from, recipients,
-                 report.success_email_subject, template_name,
-                 template_values)
+    try:
+        recipients = report.success_email_recipients + additional_recipients
+        emailer.send(config.smtp_from, recipients,
+                     report.success_email_subject, template_name,
+                     template_values)
+    except Exception as ex:
+        logging.exception(ex)

--- a/src/utils/run_reports.py
+++ b/src/utils/run_reports.py
@@ -12,8 +12,13 @@ def publish_report(wrapper, name, version):
 
 
 def run_reports(wrapper, config, reports, success_callback):
+
     running_reports = {}
     new_versions = {}
+
+    if wrapper.ow is None:
+        logging.error("Orderlyweb authentication failed; could not begin task")
+        return new_versions
 
     # Start configured reports
     for report in reports:

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,0 +1,3 @@
+class ExceptionMatching(str):
+    def __eq__(self, other):
+        return str(self) == str(other)

--- a/test/unit/test_email.py
+++ b/test/unit/test_email.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch, call
-from src.utils.email import Emailer
+from src.utils.email import Emailer, send_email
+from test import ExceptionMatching
 
 
 @patch("smtplib.SMTP")
@@ -30,3 +31,12 @@ def test_send_without_login(smtp):
                   "group": "group1",
                   "touchstone": "tid"})
     smtp.return_value.login.assert_not_called()
+
+
+@patch("src.utils.email.logging")
+def test_send_handles_exceptions(logging):
+    send_email(None, None, None, None, None, None)
+    expected_error = AttributeError(
+        "'NoneType' object has no attribute 'success_email_recipients'")
+    logging.exception.assert_called_once_with(
+        ExceptionMatching(expected_error))


### PR DESCRIPTION
This PR makes the `run_reports` and `run_diagnostic_reports` methods more robust to failures. In particular, in these 2 scenarios:
* email sending fails
* authenticating with orderlyweb fails

we should log and handle errors. How we actually monitor/report on these errors is TBC: https://mrc-ide.myjetbrains.com/youtrack/issue/VIMC-4146