### PR TITLE
mrc-4351 Add utc_time and scenario as parameters to diagnostic report task

### DIFF
--- a/config/email_templates/diagnostic_report.html
+++ b/config/email_templates/diagnostic_report.html
@@ -7,9 +7,12 @@
     Thank you for uploading your estimates for {disease} for the {touchstone} touchstone.
     This is an automated email with a link to your diagnostic report:
 </p>
-
-<a href="{report_version_url}">{report_version_url}</a>
-
+<p>
+    <a href="{report_version_url}">{report_version_url}</a>
+</p>
+<p>
+    These estimates were received for scenario: {scenario}, on {utc_time} ({eastern_time}).
+</p>
 <p>
     Please reply to this email to let us know:
 </p>

--- a/config/email_templates/diagnostic_report.txt
+++ b/config/email_templates/diagnostic_report.txt
@@ -3,6 +3,8 @@ This is an automated email with a link to your diagnostic report:
 
 {report_version_url}
 
+These estimates were received for scenario: {scenario}, on {utc_time} ({eastern_time}).
+
 Please reply to this email to let us know:
 - whether the estimates in the report make sense to you
 - whether you'd like VIMC to accept these estimates, or if you will need to provide re-runs

--- a/src/task_run_diagnostic_reports.py
+++ b/src/task_run_diagnostic_reports.py
@@ -12,7 +12,7 @@ from src.orderlyweb_client_wrapper import OrderlyWebClientWrapper
 def run_diagnostic_reports(group,
                            disease,
                            touchstone,
-                           utc_time, #ISO string e.g 2020-11-03T10:15:30
+                           utc_time,  # ISO string e.g 2020-11-03T10:15:30
                            scenario,
                            *additional_recipients):
 

--- a/test/integration/test_email.py
+++ b/test/integration/test_email.py
@@ -19,13 +19,19 @@ def test_send():
                  {"disease": "d1",
                   "report_version_url": "http://test.com/test_report_version",
                   "touchstone": "tid",
-                  "group": "G1"})
+                  "group": "G1",
+                  "scenario": "no vaccination",
+                  "utc_time": "Wed 04 Nov 2020 12:22:53 UTC",
+                  "eastern_time": "Wed 04 Nov 2020 07:22:53 ET"
+                  })
 
     expected_text = """Thank you for uploading your estimates for d1 """ + \
                     """for the tid touchstone.
 This is an automated email with a link to your diagnostic report:
 
 http://test.com/test_report_version
+
+These estimates were received for scenario: no vaccination, on Wed 04 Nov 2020 12:22:53 UTC (Wed 04 Nov 2020 07:22:53 ET).
 
 Please reply to this email to let us know:
 - whether the estimates in the report make sense to you
@@ -42,10 +48,13 @@ Please reply to this email to let us know:
     Thank you for uploading your estimates for d1 for the tid touchstone.
     This is an automated email with a link to your diagnostic report:
 </p>
-
-<a href="http://test.com/test_report_version">""" + \
+<p>
+    <a href="http://test.com/test_report_version">""" + \
                     """http://test.com/test_report_version</a>
-
+</p>
+<p>
+    These estimates were received for scenario: no vaccination, on Wed 04 Nov 2020 12:22:53 UTC (Wed 04 Nov 2020 07:22:53 ET).
+</p>
 <p>
     Please reply to this email to let us know:
 </p>

--- a/test/integration/test_email.py
+++ b/test/integration/test_email.py
@@ -31,7 +31,8 @@ This is an automated email with a link to your diagnostic report:
 
 http://test.com/test_report_version
 
-These estimates were received for scenario: no vaccination, on Wed 04 Nov 2020 12:22:53 UTC (Wed 04 Nov 2020 07:22:53 ET).
+These estimates were received for scenario: no vaccination, on Wed 04 """ +\
+                    """Nov 2020 12:22:53 UTC (Wed 04 Nov 2020 07:22:53 ET).
 
 Please reply to this email to let us know:
 - whether the estimates in the report make sense to you
@@ -53,7 +54,8 @@ Please reply to this email to let us know:
                     """http://test.com/test_report_version</a>
 </p>
 <p>
-    These estimates were received for scenario: no vaccination, on Wed 04 Nov 2020 12:22:53 UTC (Wed 04 Nov 2020 07:22:53 ET).
+    These estimates were received for scenario: no vaccination, on Wed """ +\
+                    """04 Nov 2020 12:22:53 UTC (Wed 04 Nov 2020 07:22:53 ET).
 </p>
 <p>
     Please reply to this email to let us know:

--- a/test/integration/test_task_run_diagnostic_reports.py
+++ b/test/integration/test_task_run_diagnostic_reports.py
@@ -14,6 +14,8 @@ def test_run_diagnostic_reports():
     result = run_diagnostic_reports("testGroup",
                                     "testDisease",
                                     "tid",
+                                    "2020-11-01T01:02:03",
+                                    "s1",
                                     "estimate_uploader@example.com",
                                     "estimate_uploader2@example.com")
     versions = list(result.keys())
@@ -24,6 +26,8 @@ def test_run_diagnostic_reports():
 This is an automated email with a link to your diagnostic report:
 
 {}
+
+These estimates were received for scenario: s1, on Sun 01 Nov 2020 01:02:03 UTC (Sat 31 Oct 2020 20:02:03 ET).
 
 Please reply to this email to let us know:
 - whether the estimates in the report make sense to you
@@ -41,9 +45,12 @@ Please reply to this email to let us know:
                     """tid touchstone.
     This is an automated email with a link to your diagnostic report:
 </p>
-
-<a href="{}">{}</a>
-
+<p>
+    <a href="{}">{}</a>
+</p>
+<p>
+    These estimates were received for scenario: s1, on Sun 01 Nov 2020 01:02:03 UTC (Sat 31 Oct 2020 20:02:03 ET).
+</p>
 <p>
     Please reply to this email to let us know:
 </p>
@@ -85,10 +92,12 @@ Please reply to this email to let us know:
 
 
 def test_run_reports_no_group_config():
-    versions = run_diagnostic_reports("noGroup", "noDisease", "t1")
+    versions = run_diagnostic_reports("noGroup", "noDisease", "t1",
+                                      "2020-11-01 01:02:03", "s1")
     assert len(versions) == 0
 
 
 def test_run_reports_no_disease_config():
-    versions = run_diagnostic_reports("testGroup", "noDisease", "t1")
+    versions = run_diagnostic_reports("testGroup", "noDisease", "t1",
+                                      "2020-11-01 01:02:03", "s1")
     assert len(versions) == 0

--- a/test/integration/test_task_run_diagnostic_reports.py
+++ b/test/integration/test_task_run_diagnostic_reports.py
@@ -27,7 +27,8 @@ This is an automated email with a link to your diagnostic report:
 
 {}
 
-These estimates were received for scenario: s1, on Sun 01 Nov 2020 01:02:03 UTC (Sat 31 Oct 2020 20:02:03 ET).
+These estimates were received for scenario: s1, on Sun 01 Nov 2020 """ +\
+                    """01:02:03 UTC (Sat 31 Oct 2020 20:02:03 ET).
 
 Please reply to this email to let us know:
 - whether the estimates in the report make sense to you
@@ -49,7 +50,8 @@ Please reply to this email to let us know:
     <a href="{}">{}</a>
 </p>
 <p>
-    These estimates were received for scenario: s1, on Sun 01 Nov 2020 01:02:03 UTC (Sat 31 Oct 2020 20:02:03 ET).
+    These estimates were received for scenario: s1, on Sun 01 Nov 2020 """ +\
+                    """01:02:03 UTC (Sat 31 Oct 2020 20:02:03 ET).
 </p>
 <p>
     Please reply to this email to let us know:

--- a/test/integration/test_worker.py
+++ b/test/integration/test_worker.py
@@ -8,9 +8,15 @@ def test_run_diagnostic_reports():
     versions = app.signature(sig,
                              ["testGroup",
                               "testDisease",
-                              "touchstone"]).delay().get()
+                              "touchstone",
+                              "2020-11-04T12:21:15",
+                              "no_vaccination"]).delay().get()
     assert len(versions) == 2
 
 
 def test_run_diagnostic_reports_nowait():
-    app.send_task(sig, ["testGroup", "testDisease", "touchstone"])
+    app.send_task(sig, ["testGroup",
+                        "testDisease",
+                        "touchstone",
+                        "2020-11-04T12:21:15",
+                        "no_vaccination"])

--- a/test/unit/test_email.py
+++ b/test/unit/test_email.py
@@ -3,12 +3,14 @@ from src.utils.email import Emailer, send_email
 from test import ExceptionMatching
 
 test_template_values = {"disease": "d1",
-                  "report_version_url": "http://test.com/test_report_version",
-                  "group": "group1",
-                  "touchstone": "tid",
-                  "scenario": "no vaccination",
-                  "utc_time": "Wed 03 Nov 2020 12:21:53 UTC",
-                  "eastern_time": "Wed 03 Nov 2020 07:21:53 ET"}
+                        "report_version_url":
+                            "http://test.com/test_report_version",
+                        "group": "group1",
+                        "touchstone": "tid",
+                        "scenario": "no vaccination",
+                        "utc_time": "Wed 03 Nov 2020 12:21:53 UTC",
+                        "eastern_time": "Wed 03 Nov 2020 07:21:53 ET"}
+
 
 @patch("smtplib.SMTP")
 def test_send_with_login(smtp):

--- a/test/unit/test_email.py
+++ b/test/unit/test_email.py
@@ -2,6 +2,13 @@ from unittest.mock import patch, call
 from src.utils.email import Emailer, send_email
 from test import ExceptionMatching
 
+test_template_values = {"disease": "d1",
+                  "report_version_url": "http://test.com/test_report_version",
+                  "group": "group1",
+                  "touchstone": "tid",
+                  "scenario": "no vaccination",
+                  "utc_time": "Wed 03 Nov 2020 12:21:53 UTC",
+                  "eastern_time": "Wed 03 Nov 2020 07:21:53 ET"}
 
 @patch("smtplib.SMTP")
 def test_send_with_login(smtp):
@@ -10,10 +17,7 @@ def test_send_with_login(smtp):
                  ["to1@example.com"],
                  "New version of Orderly report",
                  "diagnostic_report",
-                 {"disease": "d1",
-                  "report_version_url": "http://test.com/test_report_version",
-                  "group": "group1",
-                  "touchstone": "tid"})
+                 test_template_values)
     smtp.return_value.login.assert_has_calls([
         call("username", "password"),
     ])
@@ -26,10 +30,7 @@ def test_send_without_login(smtp):
                  ["to1@example.com"],
                  "New version of Orderly report",
                  "diagnostic_report",
-                 {"disease": "d1",
-                  "report_version_url": "http://test.com/test_report_version",
-                  "group": "group1",
-                  "touchstone": "tid"})
+                 test_template_values)
     smtp.return_value.login.assert_not_called()
 
 

--- a/test/unit/test_send_diagnostic_report_email.py
+++ b/test/unit/test_send_diagnostic_report_email.py
@@ -8,6 +8,16 @@ reports = [ReportConfig("r1", None, ["r1@example.com"], "Subj: r1",
            ReportConfig("r2", {"p1": "v1"}, ["r2@example.com"], "Subj: r2",
                         2000)]
 
+def get_test_template_values(url):
+    return {
+             "report_version_url": url,
+             "disease": "diseaseId",
+             "group": "groupId",
+             "touchstone": "touchstoneId",
+             "scenario": "no_vaccination",
+             "utc_time": "Wed 04 Nov 2020 12:22:53 UTC",
+             "eastern_time": "Wed 04 Nov 2020 07:22:53 ET"
+             }
 
 @patch("src.task_run_diagnostic_reports.send_email")
 def test_url_encodes_url_in_email(send_email):
@@ -22,18 +32,15 @@ def test_url_encodes_url_in_email(send_email):
                                  "groupId",
                                  "diseaseId",
                                  "touchstoneId",
+                                 "2020-11-04T12:22:53",
+                                 "no_vaccination",
                                  mock_config)
     url = "http://orderly-web/report/{}/1234-abcd/".format(encoded, encoded)
     send_email.assert_has_calls([
         call(fake_emailer,
              report,
              "diagnostic_report",
-             {
-                 "report_version_url": url,
-                 "disease": "diseaseId",
-                 "group": "groupId",
-                 "touchstone": "touchstoneId"
-             },
+             get_test_template_values(url),
              mock_config, list())])
 
 
@@ -49,6 +56,8 @@ def test_additional_recipients_used(send_email):
                                  "groupId",
                                  "diseaseId",
                                  "touchstoneId",
+                                 "2020-11-04T12:22:53",
+                                 "no_vaccination",
                                  mock_config,
                                  "someone@example.com")
     url = "http://orderly-web/report/{}/1234-abcd/".format(name)
@@ -56,12 +65,7 @@ def test_additional_recipients_used(send_email):
         call(fake_emailer,
              report,
              "diagnostic_report",
-             {
-                 "report_version_url": url,
-                 "disease": "diseaseId",
-                 "group": "groupId",
-                 "touchstone": "touchstoneId"
-             },
+             get_test_template_values(url),
              mock_config, ["someone@example.com"])])
 
 
@@ -77,6 +81,8 @@ def test_additional_recipients_not_used(send_email):
                                  "groupId",
                                  "diseaseId",
                                  "touchstoneId",
+                                 "2020-11-04T12:22:53",
+                                 "no_vaccination",
                                  mock_config,
                                  "someone@example.com")
     url = "http://orderly-web/report/{}/1234-abcd/".format(name)
@@ -84,10 +90,5 @@ def test_additional_recipients_not_used(send_email):
         call(fake_emailer,
              report,
              "diagnostic_report",
-             {
-                 "report_version_url": url,
-                 "disease": "diseaseId",
-                 "group": "groupId",
-                 "touchstone": "touchstoneId"
-             },
+             get_test_template_values(url),
              mock_config, list())])

--- a/test/unit/test_send_diagnostic_report_email.py
+++ b/test/unit/test_send_diagnostic_report_email.py
@@ -8,6 +8,7 @@ reports = [ReportConfig("r1", None, ["r1@example.com"], "Subj: r1",
            ReportConfig("r2", {"p1": "v1"}, ["r2@example.com"], "Subj: r2",
                         2000)]
 
+
 def get_test_template_values(url):
     return {
              "report_version_url": url,
@@ -18,6 +19,7 @@ def get_test_template_values(url):
              "utc_time": "Wed 04 Nov 2020 12:22:53 UTC",
              "eastern_time": "Wed 04 Nov 2020 07:22:53 ET"
              }
+
 
 @patch("src.task_run_diagnostic_reports.send_email")
 def test_url_encodes_url_in_email(send_email):


### PR DESCRIPTION
I did wonder if we could do without utc_time as a parameter and just let the task use now when it receives the request - but since the task might theoretically have to wait for a while before being triggered, it seemed safer to leave as a param.