### PR TITLE
vimc-4589 Migrate to gha and fix tests for new orderly server interface

### DIFF
--- a/.github/workflows/test-and-push.yml
+++ b/.github/workflows/test-and-push.yml
@@ -35,4 +35,6 @@ jobs:
         uses: codecov/codecov-action@v1
 
       - name: Push docker
-        run: ./scripts/push-docker.sh
+        run: |
+          echo ${{secrets.VAULT_DOCKERHUB_USERNAME}} | docker login -u ${{secrets.VAULT_DOCKERHUB_PASSWORD}} --password-stdin
+          ./scripts/push-docker.sh

--- a/.github/workflows/test-and-push.yml
+++ b/.github/workflows/test-and-push.yml
@@ -35,6 +35,10 @@ jobs:
         uses: codecov/codecov-action@v1
 
       - name: Push docker
+        env:
+          VAULT_DOCKERHUB_USERNAME: ${{ secrets.VAULT_DOCKERHUB_USERNAME }}
+          VAULT_DOCKERHUB_PASSWORD: ${{ secrets.VAULT_DOCKERHUB_PASSWORD }}
         run: |
-          echo ${{secrets.VAULT_DOCKERHUB_USERNAME}} | docker login -u ${{secrets.VAULT_DOCKERHUB_PASSWORD}} --password-stdin
+          echo $VAULT_DOCKERHUB_USERNAME | \
+            docker login -u $VAULT_DOCKERHUB_PASSWORD --password-stdin
           ./scripts/push-docker.sh

--- a/.github/workflows/test-and-push.yml
+++ b/.github/workflows/test-and-push.yml
@@ -1,4 +1,4 @@
-name: test
+name: test-and-push
 on: [push]
 jobs:
   test:

--- a/.github/workflows/test-and-push.yml
+++ b/.github/workflows/test-and-push.yml
@@ -39,6 +39,6 @@ jobs:
           VAULT_DOCKERHUB_USERNAME: ${{ secrets.VAULT_DOCKERHUB_USERNAME }}
           VAULT_DOCKERHUB_PASSWORD: ${{ secrets.VAULT_DOCKERHUB_PASSWORD }}
         run: |
-          echo $VAULT_DOCKERHUB_USERNAME | \
-            docker login -u $VAULT_DOCKERHUB_PASSWORD --password-stdin
+          echo $VAULT_DOCKERHUB_PASSWORD | \
+            docker login -u $VAULT_DOCKERHUB_USERNAME --password-stdin
           ./scripts/push-docker.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,3 +33,6 @@ jobs:
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
+
+      - name: Push docker
+        run: ./scripts/push-docker.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,26 +7,26 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Set up Python
-          uses: actions/setup-python@v2
-          with:
-            python-version: 3.6
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.6
 
       - name: Install dependencies
-          run: |
-            pip3 install pytest-cov pycodestyle codecov
-            pip3 install -r requirements.txt
+        run: |
+          pip3 install pytest-cov pycodestyle codecov
+          pip3 install -r requirements.txt
 
       - name: Run dependencies
-          run: ./scripts/run-dependencies.sh
+        run: ./scripts/run-dependencies.sh
 
       - name: Build docker
-          run: ./scripts/build-docker.sh
+        run: ./scripts/build-docker.sh
 
       - name: Run docker worker
-          run: ./scripts/run-docker-worker.sh
+        run: ./scripts/run-docker-worker.sh
 
       - name: Run tests
-          run: pytest --cov=src
+        run: pytest --cov=src
 
       - name: Lint
         run: pycodestyle .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,35 @@
+name: test
+on: [push]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python
+          uses: actions/setup-python@v2
+          with:
+            python-version: 3.6
+
+      - name: Install dependencies
+          run: |
+            pip3 install pytest-cov pycodestyle codecov
+            pip3 install -r requirements.txt
+
+      - name: Run dependencies
+          run: ./scripts/run-dependencies.sh
+
+      - name: Build docker
+          run: ./scripts/build-docker.sh
+
+      - name: Run docker worker
+          run: ./scripts/run-docker-worker.sh
+
+      - name: Run tests
+          run: pytest --cov=src
+
+      - name: Lint
+        run: pycodestyle .
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ celery[redis]
 future
 pyyaml
 montagu>=0.0.2
-orderlyweb-api>=0.0.9
+orderlyweb-api>=0.0.10

--- a/scripts/orderly-web.yml
+++ b/scripts/orderly-web.yml
@@ -5,13 +5,20 @@ network: montagu_default
 volumes:
   orderly: orderly_volume
   proxy_logs: orderly_web_proxy_logs
-
+  redis: orderly_web_redis_data
+## Redis configuration
+redis:
+  image:
+    name: redis
+    tag: "5.0"
+  volume: orderly_web_redis_data
 ## Orderly configuration
 orderly:
   image:
     repo: vimc
     name: orderly.server
     tag: master
+    worker_name: orderly.server
   initial:
     source: clone
     url: https://github.com/vimc/orderly-demo

--- a/scripts/run-dependencies.sh
+++ b/scripts/run-dependencies.sh
@@ -14,7 +14,7 @@ docker-compose pull
 docker-compose --project-name montagu up -d
 
 # Clear redis
-docker exec -it montagu_mq_1 redis-cli FLUSHALL
+docker exec montagu_mq_1 redis-cli FLUSHALL
 
 # Install orderly-web
 pip3 install orderly-web

--- a/src/utils/run_reports.py
+++ b/src/utils/run_reports.py
@@ -73,7 +73,10 @@ def run_reports(wrapper, group, disease, config, reports, success_callback,
                             logging.error(
                                 "Failed to publish report version {}-{}"
                                 .format(name, version))
-                        new_versions[version] = {"published": published}
+                        new_versions[version] = {
+                            "published": published,
+                            "report": name
+                        }
                     else:
                         logging.error("Failure for key {}.".format(key))
 

--- a/test/integration/test_task_run_diagnostic_reports.py
+++ b/test/integration/test_task_run_diagnostic_reports.py
@@ -82,7 +82,7 @@ Please reply to this email to let us know:
                        "estimate_uploader2@example.com"]
     }
 
-    minimal_is_first = (result[versions[0]]["report"]) == "minimal"
+    minimal_is_first = result[versions[0]]["report"] == "minimal"
 
     if minimal_is_first:
         report_1 = "minimal"

--- a/test/integration/test_task_run_diagnostic_reports.py
+++ b/test/integration/test_task_run_diagnostic_reports.py
@@ -68,25 +68,45 @@ Please reply to this email to let us know:
 </body>
 </html>"""
 
-    report_1 = "minimal"
-    report_2 = "other"
+    minimal_email_props = {
+        "subject": "VIMC diagnostic report: tid - testGroup - testDisease",
+        "recipients": ["minimal_modeller@example.com", "science@example.com",
+                       "estimate_uploader@example.com",
+                       "estimate_uploader2@example.com"]
+    }
+
+    other_email_props = {
+        "subject": "New version of another Orderly report",
+        "recipients": ["other_modeller@example.com", "science@example.com",
+                       "estimate_uploader@example.com",
+                       "estimate_uploader2@example.com"]
+    }
+
+    minimal_is_first = (result[versions[0]]["report"]) == "minimal"
+
+    if minimal_is_first:
+        report_1 = "minimal"
+        report_2 = "other"
+        email_props = [minimal_email_props, other_email_props]
+    else:
+        report_1 = "other"
+        report_2 = "minimal"
+        email_props = [other_email_props, minimal_email_props]
+
     url_template = "http://localhost:8888/report/{}/{}/"
     url_1 = url_template.format(report_1, versions[0])
     url_2 = url_template.format(report_2, versions[1])
+
     smtp.assert_emails_match([
         FakeEmailProperties(
-            "VIMC diagnostic report: tid - testGroup - testDisease",
-            ["minimal_modeller@example.com", "science@example.com",
-             "estimate_uploader@example.com",
-             "estimate_uploader2@example.com"],
+            email_props[0]["subject"],
+            email_props[0]["recipients"],
             "noreply@example.com",
             expected_text.format(url_1),
             expected_html.format(url_1, url_1)),
         FakeEmailProperties(
-            "New version of another Orderly report",
-            ["other_modeller@example.com", "science@example.com",
-             "estimate_uploader@example.com",
-             "estimate_uploader2@example.com"],
+            email_props[1]["subject"],
+            email_props[1]["recipients"],
             "noreply@example.com",
             expected_text.format(url_2),
             expected_html.format(url_2, url_2))

--- a/test/integration/test_worker.py
+++ b/test/integration/test_worker.py
@@ -53,7 +53,7 @@ def test_later_task_kills_earlier_task_report():
     config = Config()
     wrapper = OrderlyWebClientWrapper(config)
     result = wrapper.execute(wrapper.ow.report_status, first_report_key)
-    assert result.status == "killed"
+    assert result.status == "interrupted"
     assert result.finished
 
     # Check redis key has been tidied up

--- a/test/unit/test_orderlyweb_client_wrapper.py
+++ b/test/unit/test_orderlyweb_client_wrapper.py
@@ -67,7 +67,7 @@ def test_retries_when_token_expired(logging):
     versions = run_reports(wrapper, group, disease, MockConfig(), reports,
                            success_callback, mock_running_reports)
 
-    assert versions == {"r1-version": {"published": True}}
+    assert versions == {"r1-version": {"published": True, "report": "r1"}}
     logging.info.assert_has_calls([
         call("Running report: r1. Key is r1-key. Timeout is 1000s."),
         call("Success for key r1-key. New version is r1-version"),

--- a/test/unit/test_run_reports.py
+++ b/test/unit/test_run_reports.py
@@ -44,8 +44,8 @@ def test_run_reports(logging):
                            success_callback, mock_running_reports)
 
     assert versions == {
-        "r1-version": {"published": True},
-        "r2-version": {"published": True}
+        "r1-version": {"published": True, "report": "r1"},
+        "r2-version": {"published": True, "report": "r2"}
     }
 
     logging.info.assert_has_calls([
@@ -92,8 +92,8 @@ def test_run_reports_kills_currently_running(logging):
                            success_callback, mock_running_reports)
 
     assert versions == {
-        "r1-version": {"published": True},
-        "r2-version": {"published": True}
+        "r1-version": {"published": True, "report": "r1"},
+        "r2-version": {"published": True, "report": "r2"}
     }
 
     logging.info.assert_has_calls([
@@ -145,8 +145,8 @@ def test_run_reports_with_additional_recipients(logging):
                            success_callback, mock_running_reports)
 
     assert versions == {
-        "r1-version": {"published": True},
-        "r2-version": {"published": True}
+        "r1-version": {"published": True, "report": "r1"},
+        "r2-version": {"published": True, "report": "r2"}
     }
 
     logging.info.assert_has_calls([
@@ -198,8 +198,8 @@ def test_run_reports_finish_on_different_poll_cycles(logging):
                            success_callback, mock_running_reports)
 
     assert versions == {
-        "r2-version": {"published": True},
-        "r1-version": {"published": True}
+        "r2-version": {"published": True, "report": "r2"},
+        "r1-version": {"published": True, "report": "r1"}
     }
 
     logging.info.assert_has_calls([
@@ -241,7 +241,7 @@ def test_run_reports_with_run_error(logging):
                            success_callback, mock_running_reports)
 
     assert versions == {
-        "r2-version": {"published": True}
+        "r2-version": {"published": True, "report": "r2"}
     }
 
     logging.info.assert_has_calls([
@@ -295,7 +295,7 @@ def test_run_reports_with_status_error(logging):
                            success_callback, mock_running_reports)
 
     assert versions == {
-        "r2-version": {"published": True}
+        "r2-version": {"published": True, "report": "r2"}
     }
 
     logging.info.assert_has_calls([
@@ -339,7 +339,7 @@ def test_run_reports_with_status_failure(logging):
                            success_callback, mock_running_reports)
 
     assert versions == {
-        "r1-version": {"published": True}
+        "r1-version": {"published": True, "report": "r1"}
     }
 
     logging.info.assert_has_calls([
@@ -384,8 +384,8 @@ def test_run_reports_with_publish_failure(logging):
                            success_callback, mock_running_reports)
 
     assert versions == {
-        "r1-version": {"published": True},
-        "r2-version": {"published": False}
+        "r1-version": {"published": True, "report": "r1"},
+        "r2-version": {"published": False, "report": "r2"}
     }
 
     logging.info.assert_has_calls([


### PR DESCRIPTION
I think this should be the last PR in this set!

Replace travis script with gha, and update tests for new orderly server behaviour. Use latest version of orderly web python client which deals with changed run endpoint.

Simulataneously running reports may now finish in any order (it was deterministic before that they finished in the order they were started) - so we can't rely on the expected report completion emails to be sent in a particular order. Hence the additional logic in the integration test, and adding an extra 'report' property to the result objects (these are really only used by the tests) to determine the expected email properties from the order the reports finished. 