### PR TITLE
vimc-5014 basic functionality to create YT tickets on successful report creation

### DIFF
--- a/.github/workflows/test-and-push.yml
+++ b/.github/workflows/test-and-push.yml
@@ -3,6 +3,8 @@ on: [push]
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      YOUTRACK_TOKEN: ${{ secrets.YOUTRACK_TOKEN }}
     steps:
       - uses: actions/checkout@v2
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ If you end
 up with an old worker still running (which causes new workers to complain that another node is already listening), you
 kill all dev workers with `pkill -9 -f 'celery -A src worker'`.
 
-
+YouTrack tickets will be created if you have an environment variable `YOUTRACK_TOKEN` in your environment with a valid 
+YouTrack permanent API token.
 
 ## Testing
 
@@ -54,3 +55,7 @@ The worker expects to find a config file at `config/config.yml`.
 The Dockerfile copies `config/docker_config.yml` to `config/config.yml`.
 This allows the worker running on metal to use a broker on `localhost` while the worker in docker needs to use
 `montagu_mq`, the container name of the broker, to access its port. 
+
+Note that if a YouTrack token is not provided in the config the app will look for an environment variable called `YOUTRACK_TOKEN`. 
+This makes local and automated testing of the YouTrack integration possible. 
+During `montagu` deployment a token from the vault will be added to the config.

--- a/config/config.yml
+++ b/config/config.yml
@@ -7,7 +7,7 @@ servers:
   orderlyweb:
     url: http://localhost:8888
   youtrack:
-    token: <TOKEN HERE>
+    token: None
   smtp:
     host: localhost
     port: 1025

--- a/config/config.yml
+++ b/config/config.yml
@@ -6,6 +6,8 @@ servers:
     password: password
   orderlyweb:
     url: http://localhost:8888
+  youtrack:
+    token: <TOKEN HERE>
   smtp:
     host: localhost
     port: 1025
@@ -26,6 +28,7 @@ tasks:
                 - science@example.com
               subject: "VIMC diagnostic report: {touchstone} - {group} - {disease}"
             timeout: 300
+            assignee: a.hill
           - report_name: diagnostic-param
             parameters:
               nmin: 0
@@ -35,4 +38,4 @@ tasks:
                 - science@example.com
               subject: "New version of another Orderly report"
             timeout: 1200
-
+            assignee: e.russell

--- a/config/docker_config.yml
+++ b/config/docker_config.yml
@@ -6,6 +6,8 @@ servers:
     password: password
   orderlyweb:
     url: http://montagu_orderly_web:8888
+  youtrack:
+    token:
   smtp:
     host: montagu_smtp_server_1
     port: 1025
@@ -23,6 +25,7 @@ tasks:
                 - minimal_modeller@example.com
                 - science@example.com
               subject:  "VIMC diagnostic report: {touchstone} - {group} - {disease}"
+            assignee: a.hill
           - report_name: diagnostic-param
             parameters:
               nmin: 0
@@ -31,3 +34,4 @@ tasks:
                 - other_modeller@example.com
                 - science@example.com
               subject: "New version of another Orderly report"
+            assignee: a.hill

--- a/config/docker_config.yml
+++ b/config/docker_config.yml
@@ -34,4 +34,4 @@ tasks:
                 - other_modeller@example.com
                 - science@example.com
               subject: "New version of another Orderly report"
-            assignee: a.hill
+            assignee: e.russell

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+YTClient
 celery[redis]
 future
 pyyaml

--- a/scripts/run-docker-worker.sh
+++ b/scripts/run-docker-worker.sh
@@ -4,4 +4,7 @@ set -ex
 HERE=$(readlink -f "$(dirname $0)")
 . $HERE/common.sh
 
-docker run --name $NAME --network=montagu_default -d $BRANCH_TAG
+docker run --env YOUTRACK_TOKEN=$YOUTRACK_TOKEN \
+    --name $NAME \
+    --network=montagu_default \
+    -d $BRANCH_TAG

--- a/src/config.py
+++ b/src/config.py
@@ -8,12 +8,14 @@ class ReportConfig:
                  parameters,
                  success_email_recipients,
                  success_email_subject,
-                 timeout):
+                 timeout,
+                 assignee):
         self.name = name
         self.parameters = parameters
         self.success_email_recipients = success_email_recipients
         self.success_email_subject = success_email_subject
         self.timeout = timeout
+        self.assignee = assignee
 
 
 class Config:
@@ -40,6 +42,10 @@ class Config:
     @property
     def orderlyweb_url(self):
         return self.__server("orderlyweb")["url"]
+
+    @property
+    def youtrack_token(self):
+        return self.__server("youtrack")["token"]
 
     @property
     def report_poll_seconds(self):
@@ -80,12 +86,14 @@ class Config:
                 recipients = self.__value_or_default(email, "recipients", [])
                 subject = self.__value_or_default(email, "subject", "")
                 timeout = self.__value_or_default(r, "timeout", 600)
+                assignee = r["assignee"]
 
                 result.append(ReportConfig(r["report_name"],
                                            params,
                                            recipients,
                                            subject,
-                                           timeout))
+                                           timeout,
+                                           assignee))
         return result
 
     def __server(self, name):

--- a/src/task_run_diagnostic_reports.py
+++ b/src/task_run_diagnostic_reports.py
@@ -26,7 +26,7 @@ def run_diagnostic_reports(group,
         emailer = Emailer(config.smtp_host, config.smtp_port,
                           config.smtp_user, config.smtp_password)
         yt = YTClient('https://mrc-ide.myjetbrains.com/youtrack/',
-                          token=config.youtrack_token)
+                      token=config.youtrack_token)
 
         def success_callback(report, version):
             send_diagnostic_report_email(emailer,
@@ -60,14 +60,15 @@ def run_diagnostic_reports(group,
 
 def create_ticket(group, disease, touchstone,
                   report: ReportConfig, version,
-                  client: YTClient,
+                  yt: YTClient,
                   config: Config):
     try:
-        issue = client.create_issue(Project("78-0"),
+        issue = yt.create_issue(Project("78-0"),
                                 "Check & share diag report with {} ({}) {}"
                                 .format(group, disease, touchstone),
                                 get_version_url(report, version, config))
-        client.run_command(Command([issue], "Assignee {}".format(report.assignee)))
+        yt.run_command(
+            Command([issue], "Assignee {}".format(report.assignee)))
     except Exception as ex:
         logging.exception(ex)
 

--- a/src/task_run_diagnostic_reports.py
+++ b/src/task_run_diagnostic_reports.py
@@ -69,6 +69,12 @@ def create_ticket(group, disease, touchstone,
                                 get_version_url(report, version, config))
         yt.run_command(
             Command([issue], "Assignee {}".format(report.assignee)))
+        yt.run_command(
+            Command([issue], "tag {}".format(group)))
+        yt.run_command(
+            Command([issue], "tag {}".format(disease)))
+        yt.run_command(
+            Command([issue], "tag {}".format(touchstone)))
     except Exception as ex:
         logging.exception(ex)
 

--- a/src/task_run_diagnostic_reports.py
+++ b/src/task_run_diagnostic_reports.py
@@ -77,13 +77,10 @@ def create_ticket(group, disease, touchstone,
                                 .format(group, disease, touchstone),
                                 get_version_url(report, version, config))
         yt.run_command(
-            Command([issue], "Assignee {}".format(report.assignee)))
-        yt.run_command(
-            Command([issue], "tag {}".format(group)))
-        yt.run_command(
-            Command([issue], "tag {}".format(disease)))
-        yt.run_command(
-            Command([issue], "tag {}".format(touchstone)))
+            Command([issue],
+                    "for {} tag {} tag {} tag {}".format(report.assignee,
+                                                         group, disease,
+                                                         touchstone)))
     except Exception as ex:
         logging.exception(ex)
 

--- a/test/integration/test_config.py
+++ b/test/integration/test_config.py
@@ -24,7 +24,7 @@ def test_orderlyweb_url():
 
 
 def test_youtrack_token():
-    assert config.youtrack_token == "<TOKEN HERE>"
+    assert config.youtrack_token == "None"
 
 
 def test_report_poll_seconds():

--- a/test/integration/test_config.py
+++ b/test/integration/test_config.py
@@ -23,6 +23,10 @@ def test_orderlyweb_url():
     assert config.orderlyweb_url == "http://localhost:8888"
 
 
+def test_youtrack_token():
+        assert config.youtrack_token == "<TOKEN HERE>"
+
+
 def test_report_poll_seconds():
     assert config.report_poll_seconds == 5
 

--- a/test/integration/test_config.py
+++ b/test/integration/test_config.py
@@ -24,7 +24,7 @@ def test_orderlyweb_url():
 
 
 def test_youtrack_token():
-        assert config.youtrack_token == "<TOKEN HERE>"
+    assert config.youtrack_token == "<TOKEN HERE>"
 
 
 def test_report_poll_seconds():

--- a/test/integration/test_run_reports.py
+++ b/test/integration/test_run_reports.py
@@ -6,8 +6,8 @@ from src.utils.running_reports_repository import RunningReportsRepository
 
 def test_run_reports_handles_error():
     reports = [
-        ReportConfig("nonexistent", None, ["test1@test.com"], "subject1", 600),
-        ReportConfig("diagnostic", {}, ["test2@test.com"], "subject2", 600)]
+        ReportConfig("nonexistent", None, ["test1@test.com"], "subject1", 600, "a.ssignee"),
+        ReportConfig("diagnostic", {}, ["test2@test.com"], "subject2", 600, "a.ssignee")]
     config = Config()
     wrapper = OrderlyWebClientWrapper(config)
     success = {}

--- a/test/integration/test_run_reports.py
+++ b/test/integration/test_run_reports.py
@@ -6,8 +6,10 @@ from src.utils.running_reports_repository import RunningReportsRepository
 
 def test_run_reports_handles_error():
     reports = [
-        ReportConfig("nonexistent", None, ["test1@test.com"], "subject1", 600, "a.ssignee"),
-        ReportConfig("diagnostic", {}, ["test2@test.com"], "subject2", 600, "a.ssignee")]
+        ReportConfig("nonexistent", None, ["test1@test.com"], "subject1",
+                     600, "a.ssignee"),
+        ReportConfig("diagnostic", {}, ["test2@test.com"], "subject2", 600,
+                     "a.ssignee")]
     config = Config()
     wrapper = OrderlyWebClientWrapper(config)
     success = {}

--- a/test/integration/test_task_run_diagnostic_reports.py
+++ b/test/integration/test_task_run_diagnostic_reports.py
@@ -1,19 +1,11 @@
-import os
 import pytest
-
-from YTClient.YTClient import YTClient
-from YTClient.YTDataClasses import Command
 
 from src.task_run_diagnostic_reports import run_diagnostic_reports
 from test.integration.fake_smtp_utils import FakeSmtpUtils, FakeEmailProperties
-
+from test.integration.yt_utils import YouTrackUtils
 
 smtp = FakeSmtpUtils()
-
-yt_token = os.environ["YOUTRACK_TOKEN"]
-yt = YTClient('https://mrc-ide.myjetbrains.com/youtrack/',
-              token=yt_token)
-test_touchstone = "touchstone-task-runner-test"
+yt = YouTrackUtils()
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -22,16 +14,14 @@ def cleanup_emails():
 
 
 @pytest.fixture(autouse=True)
-def cleanup_tickets():
-    issues = yt.get_issues("summary: {}".format(test_touchstone))
-    if len(issues) > 0:
-        yt.run_command(Command(issues, "delete"))
+def cleanup_tickets(request):
+    request.addfinalizer(yt.cleanup)
 
 
 def test_run_diagnostic_reports():
     result = run_diagnostic_reports("testGroup",
                                     "testDisease",
-                                    test_touchstone,
+                                    yt.test_touchstone,
                                     "2020-11-01T01:02:03",
                                     "s1",
                                     "estimate_uploader@example.com",
@@ -88,7 +78,7 @@ Please reply to this email to let us know:
 </html>"""
 
     subject = "VIMC diagnostic report: {} - testGroup - testDisease" \
-        .format(test_touchstone)
+        .format(yt.test_touchstone)
     diagnostic_email_props = {
         "subject": subject,
         "recipients": ["minimal_modeller@example.com", "science@example.com",
@@ -136,18 +126,18 @@ Please reply to this email to let us know:
 
 def test_run_reports_no_group_config():
     versions = run_diagnostic_reports("noGroup", "noDisease",
-                                      test_touchstone,
+                                      yt.test_touchstone,
                                       "2020-11-01 01:02:03", "s1")
-    issues = yt.get_issues("summary: {}".format(test_touchstone))
+    issues = yt.get_issues()
     assert len(versions) == 0
     assert len(issues) == 0
 
 
 def test_run_reports_no_disease_config():
     versions = run_diagnostic_reports("testGroup", "noDisease",
-                                      test_touchstone,
+                                      yt.test_touchstone,
                                       "2020-11-01 01:02:03", "s1")
-    issues = yt.get_issues("summary: {}".format(test_touchstone))
+    issues = yt.get_issues()
     assert len(versions) == 0
     assert len(issues) == 0
 
@@ -155,12 +145,12 @@ def test_run_reports_no_disease_config():
 def test_ticket_created():
     result = run_diagnostic_reports("testGroup",
                                     "testDisease",
-                                    test_touchstone,
+                                    yt.test_touchstone,
                                     "2020-11-01T01:02:03",
                                     "s1",
                                     "estimate_uploader@example.com")
     versions = list(result.keys())
-    issues = yt.get_issues("summary: {}".format(test_touchstone),
+    issues = yt.get_issues("summary: {}".format(yt.test_touchstone),
                            fields=["summary",
                                    "description",
                                    "tags(name)",
@@ -179,7 +169,7 @@ def test_ticket_created():
 
     expected_summary = \
         "Check & share diag report with testGroup (testDisease) {}" \
-        .format(test_touchstone)
+        .format(yt.test_touchstone)
     expected_link1 = "http://localhost:8888/report/{}/{}/".format(r1, v1)
     assert i1["summary"] == expected_summary
     assert i1["description"] == expected_link1
@@ -191,7 +181,7 @@ def test_ticket_created():
     assert len(tags) == 3
     assert "testGroup" in tags
     assert "testDisease" in tags
-    assert test_touchstone in tags
+    assert yt.test_touchstone in tags
 
     expected_link2 = "http://localhost:8888/report/{}/{}/".format(r2, v2)
     assert i2["summary"] == expected_summary
@@ -204,4 +194,4 @@ def test_ticket_created():
     assert len(tags) == 3
     assert "testGroup" in tags
     assert "testDisease" in tags
-    assert test_touchstone in tags
+    assert yt.test_touchstone in tags

--- a/test/integration/test_task_run_flower.py
+++ b/test/integration/test_task_run_flower.py
@@ -1,10 +1,20 @@
 import requests
+import pytest
+
+from test.integration.yt_utils import YouTrackUtils
+
+yt = YouTrackUtils()
+
+
+@pytest.fixture(autouse=True)
+def cleanup_tickets(request):
+    request.addfinalizer(yt.cleanup)
 
 
 def test_run_task_through_flower():
     args = ["testGroup",
             "testDisease",
-            "touchstone",
+            yt.test_touchstone,
             "2020-11-04T12:21:15",
             "no_vaccination"]
     result = requests.post(

--- a/test/integration/test_worker.py
+++ b/test/integration/test_worker.py
@@ -68,11 +68,3 @@ def test_later_task_kills_earlier_task_report():
 
     # Check redis key has been tidied up
     assert running_repo.get("testGroup", "testDisease", "diagnostic") is None
-
-
-def test_run_diagnostic_reports_nowait():
-    app.send_task(sig, ["testGroup",
-                        "testDisease",
-                        yt.test_touchstone,
-                        "2020-11-04T12:21:15",
-                        "no_vaccination"])

--- a/test/integration/test_worker.py
+++ b/test/integration/test_worker.py
@@ -47,6 +47,7 @@ def test_later_task_kills_earlier_task_report():
                               "touchstone",
                               "2020-11-04T12:21:16",
                               "no_vaccination"]).delay().get()
+
     assert len(versions) == 2
 
     # Check first report key's status with OrderlyWeb - should have been killed

--- a/test/integration/yt_utils.py
+++ b/test/integration/yt_utils.py
@@ -1,0 +1,23 @@
+import os
+from YTClient.YTClient import YTClient
+from YTClient.YTDataClasses import Command
+
+
+class YouTrackUtils:
+    def __init__(self):
+        self.test_touchstone = "touchstone-task-runner-test"
+        yt_token = os.environ["YOUTRACK_TOKEN"]
+        self.yt = YTClient('https://mrc-ide.myjetbrains.com/youtrack/',
+                           token=yt_token)
+
+    def cleanup(self):
+        issues = self.yt.get_issues("tag: {}".format(self.test_touchstone))
+        if len(issues) > 0:
+            self.yt.run_command(Command(issues, "delete"))
+
+    def get_issues(self, query=None, fields=None):
+        if query is None:
+            query = "summary: {}".format(self.test_touchstone)
+        if fields is None:
+            fields = ["id"]
+        return self.yt.get_issues(query, fields)

--- a/test/unit/test_create_ticket.py
+++ b/test/unit/test_create_ticket.py
@@ -18,18 +18,10 @@ def test_create_ticket():
                            "Check & share diag report with g1 (d1) t1",
                            "http://orderly-web/report/TEST/1234/")
     mock_client.create_issue.assert_has_calls([expected_create])
-    expected_assign = call(Command(issues=["ISSUE"],
-                                   query="Assignee a.ssignee"))
-    expected_tag_group = call(Command(issues=["ISSUE"],
-                                      query="tag g1"))
-    expected_tag_disease = call(Command(issues=["ISSUE"],
-                                        query="tag d1"))
-    expected_tag_touchstone = call(Command(issues=["ISSUE"],
-                                           query="tag t1"))
-    mock_client.run_command.assert_has_calls([expected_assign,
-                                              expected_tag_group,
-                                              expected_tag_disease,
-                                              expected_tag_touchstone])
+    expected_command_query = "for a.ssignee tag g1 tag d1 tag t1"
+    expected_command = call(Command(issues=["ISSUE"],
+                                    query=expected_command_query))
+    mock_client.run_command.assert_has_calls([expected_command])
 
 
 @patch("src.task_run_diagnostic_reports.logging")

--- a/test/unit/test_create_ticket.py
+++ b/test/unit/test_create_ticket.py
@@ -1,0 +1,23 @@
+from YTClient.YTClient import YTClient
+from YTClient.YTDataClasses import Project, Command
+
+from src.task_run_diagnostic_reports import create_ticket
+from src.config import ReportConfig, Config
+from unittest.mock import call, Mock
+from test.unit.test_run_reports import MockConfig
+
+
+def test_create_ticket_on_success():
+    report = ReportConfig("TEST", {}, ["to@example.com"],
+                          "Hi", 100, "a.ssignee")
+    mock_config: Config = MockConfig()
+    mock_client = Mock(spec=YTClient("", ""))
+    mock_client.create_issue = Mock(return_value="ISSUE")
+    create_ticket("g1", "d1", "t1", report, "1234", mock_client, mock_config)
+    expected_create = call(Project(id='78-0'),
+                           'Check & share diag report with g1 (d1) t1',
+                           'http://orderly-web/report/TEST/1234/')
+    mock_client.create_issue.assert_has_calls([expected_create])
+    expected_assign = call(Command(issues=["ISSUE"],
+                                   query='Assignee a.ssignee'))
+    mock_client.run_command.assert_has_calls([expected_assign])

--- a/test/unit/test_create_ticket.py
+++ b/test/unit/test_create_ticket.py
@@ -14,10 +14,19 @@ def test_create_ticket():
     mock_client = Mock(spec=YTClient("", ""))
     mock_client.create_issue = Mock(return_value="ISSUE")
     create_ticket("g1", "d1", "t1", report, "1234", mock_client, mock_config)
-    expected_create = call(Project(id='78-0'),
-                           'Check & share diag report with g1 (d1) t1',
-                           'http://orderly-web/report/TEST/1234/')
+    expected_create = call(Project(id="78-0"),
+                           "Check & share diag report with g1 (d1) t1",
+                           "http://orderly-web/report/TEST/1234/")
     mock_client.create_issue.assert_has_calls([expected_create])
     expected_assign = call(Command(issues=["ISSUE"],
-                                   query='Assignee a.ssignee'))
-    mock_client.run_command.assert_has_calls([expected_assign])
+                                   query="Assignee a.ssignee"))
+    expected_tag_group = call(Command(issues=["ISSUE"],
+                                      query="tag g1"))
+    expected_tag_disease = call(Command(issues=["ISSUE"],
+                                        query="tag d1"))
+    expected_tag_touchstone = call(Command(issues=["ISSUE"],
+                                           query="tag t1"))
+    mock_client.run_command.assert_has_calls([expected_assign,
+                                              expected_tag_group,
+                                              expected_tag_disease,
+                                              expected_tag_touchstone])

--- a/test/unit/test_create_ticket.py
+++ b/test/unit/test_create_ticket.py
@@ -3,7 +3,7 @@ from YTClient.YTDataClasses import Project, Command
 
 from src.task_run_diagnostic_reports import create_ticket
 from src.config import ReportConfig, Config
-from unittest.mock import call, Mock
+from unittest.mock import call, Mock, patch
 from test.unit.test_run_reports import MockConfig
 
 
@@ -30,3 +30,15 @@ def test_create_ticket():
                                               expected_tag_group,
                                               expected_tag_disease,
                                               expected_tag_touchstone])
+
+
+@patch("src.task_run_diagnostic_reports.logging")
+def test_create_ticket_logs_errors(logging):
+    report = ReportConfig("TEST", {}, ["to@example.com"],
+                          "Hi", 100, "a.ssignee")
+    mock_config: Config = MockConfig()
+    mock_client = Mock(spec=YTClient("", ""))
+    test_ex = Exception("TEST EX")
+    mock_client.create_issue = Mock(side_effect=test_ex)
+    create_ticket("g1", "d1", "t1", report, "1234", mock_client, mock_config)
+    logging.exception.assert_has_calls([call(test_ex)])

--- a/test/unit/test_create_ticket.py
+++ b/test/unit/test_create_ticket.py
@@ -7,7 +7,7 @@ from unittest.mock import call, Mock
 from test.unit.test_run_reports import MockConfig
 
 
-def test_create_ticket_on_success():
+def test_create_ticket():
     report = ReportConfig("TEST", {}, ["to@example.com"],
                           "Hi", 100, "a.ssignee")
     mock_config: Config = MockConfig()

--- a/test/unit/test_orderlyweb_client_wrapper.py
+++ b/test/unit/test_orderlyweb_client_wrapper.py
@@ -6,7 +6,8 @@ from src.orderlyweb_client_wrapper import OrderlyWebClientWrapper
 from test import ExceptionMatching
 from test.unit.test_run_reports import MockConfig, MockRunningReportRepository
 
-reports = [ReportConfig("r1", None, ["r1@example.com"], "Subj: r1", 1000)]
+reports = [ReportConfig("r1", None, ["r1@example.com"],
+                        "Subj: r1", 1000, "a.ssignee")]
 
 report_response = ReportStatusResult({"status": "success",
                                       "version": "r1-version",

--- a/test/unit/test_run_reports.py
+++ b/test/unit/test_run_reports.py
@@ -5,9 +5,9 @@ from unittest.mock import patch, call, Mock
 from src.orderlyweb_client_wrapper import OrderlyWebClientWrapper
 
 reports = [ReportConfig("r1", None, ["r1@example.com"], "Subj: r1",
-                        1000),
+                        1000, "a.ssignee"),
            ReportConfig("r2", {"p1": "v1"}, ["r2@example.com"], "Subj: r2",
-                        2000)]
+                        2000, "a.ssignee")]
 
 expected_params = {
     "r1": {"touchstone": "2021test-1", "touchstone_name": "2021test"},
@@ -550,3 +550,7 @@ class MockConfig:
     @property
     def orderlyweb_url(self):
         return "http://orderly-web"
+
+    @property
+    def youtrack_token(self):
+        return "12345"

--- a/test/unit/test_run_reports.py
+++ b/test/unit/test_run_reports.py
@@ -26,11 +26,11 @@ touchstone = "2021test-1"
 
 expected_run_rpt_1_log = "Running report: r1 with parameters " \
                          "touchstone=2021test-1, touchstone_name=2021test. " \
-                            "Key is r1-key. Timeout is 1000s."
+                         "Key is r1-key. Timeout is 1000s."
 
 expected_run_rpt_2_log = "Running report: r2 with parameters p1=v1, " \
                          "touchstone=2021test-1, touchstone_name=2021test. " \
-                            "Key is r2-key. Timeout is 2000s."
+                         "Key is r2-key. Timeout is 2000s."
 
 
 @patch("src.utils.run_reports.logging")

--- a/test/unit/test_send_diagnostic_report_email.py
+++ b/test/unit/test_send_diagnostic_report_email.py
@@ -4,9 +4,9 @@ from unittest.mock import patch, call
 from test.unit.test_run_reports import MockConfig
 
 reports = [ReportConfig("r1", None, ["r1@example.com"], "Subj: r1",
-                        1000),
+                        1000, "a.ssignee"),
            ReportConfig("r2", {"p1": "v1"}, ["r2@example.com"], "Subj: r2",
-                        2000)]
+                        2000, "a.ssignee")]
 
 
 def get_test_template_values(url):
@@ -25,7 +25,8 @@ def get_test_template_values(url):
 def test_url_encodes_url_in_email(send_email):
     name = "'A silly, report"
     encoded = "%27A%20silly%2C%20report"
-    report = ReportConfig(name, {}, ["to@example.com"], "Hi", 100)
+    report = ReportConfig(name, {}, ["to@example.com"],
+                          "Hi", 100, "a.ssignee")
     fake_emailer = {}
     mock_config = MockConfig()
     send_diagnostic_report_email(fake_emailer,
@@ -49,7 +50,8 @@ def test_url_encodes_url_in_email(send_email):
 @patch("src.task_run_diagnostic_reports.send_email")
 def test_additional_recipients_used(send_email):
     name = "r1"
-    report = ReportConfig(name, {}, ["to@example.com"], "Hi", 1000)
+    report = ReportConfig(name, {}, ["to@example.com"],
+                          "Hi", 1000, "a.ssignee")
     fake_emailer = {}
     mock_config = MockConfig(use_additional_recipients=True)
     send_diagnostic_report_email(fake_emailer,
@@ -74,7 +76,8 @@ def test_additional_recipients_used(send_email):
 @patch("src.task_run_diagnostic_reports.send_email")
 def test_additional_recipients_not_used(send_email):
     name = "r1"
-    report = ReportConfig(name, {}, ["to@example.com"], "Hi", 1000)
+    report = ReportConfig(name, {}, ["to@example.com"],
+                          "Hi", 1000, "a.ssignee")
     fake_emailer = {}
     mock_config = MockConfig(use_additional_recipients=False)
     send_diagnostic_report_email(fake_emailer,


### PR DESCRIPTION
This adds the most basic first step - ticket creation on success, with a link to the report and person assigned, and tags for disease/group/touchstone.

Further PRs to follow in this repo for:
* creating ticket on failure as well
* relating tickets of same group/diseaset/touchstone combo to each other

Also needs a Montagu PR for getting the YouTrack token into the config during deployment.