### PR TITLE
update ticket if it exists

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-YTClient
 celery[redis]
 future
 pyyaml
 montagu>=0.0.2
 orderlyweb-api>=0.0.10
+git+https://github.com/reside-ic/youtrack-rest-python-library

--- a/src/task_run_diagnostic_reports.py
+++ b/src/task_run_diagnostic_reports.py
@@ -85,16 +85,32 @@ def create_ticket(group, disease, touchstone,
         description = get_version_url(report, version, config) if \
             report_success else \
             "Auto-run failed with error: {}".format(error)
-        issue = yt.create_issue(Project(vimc_project_id),
-                                summary.format(group, disease, touchstone),
-                                description)
-        yt.run_command(
-            Command([issue],
-                    "for {} implementer {} tag {} tag {} tag {}".format(
-                        report.assignee,
-                        report.assignee,
-                        group, disease,
-                        touchstone)))
+        query = "tag: {} tag: {} tag: {} status: Incoming"
+        existing_issues = yt.get_issues(
+            query.format(disease, touchstone, group),
+            ["id"])
+        summary = summary.format(group, disease, touchstone)
+        if len(existing_issues) > 0:
+            existing_issue = existing_issues[0]
+            yt.run_command(
+                Command([existing_issue],
+                        "for {} implementer {} summary {} description {}"
+                        .format(
+                            report.assignee,
+                            report.assignee,
+                            summary,
+                            description)))
+        else:
+            issue = yt.create_issue(Project(vimc_project_id),
+                                    summary,
+                                    description)
+            yt.run_command(
+                Command([issue],
+                        "for {} implementer {} tag {} tag {} tag {}".format(
+                            report.assignee,
+                            report.assignee,
+                            group, disease,
+                            touchstone)))
     except Exception as ex:
         logging.exception(ex)
 

--- a/src/task_run_diagnostic_reports.py
+++ b/src/task_run_diagnostic_reports.py
@@ -51,11 +51,11 @@ def run_diagnostic_reports(group,
                                          scenario,
                                          config,
                                          *additional_recipients)
-            create_ticket(group, disease, touchstone,
+            create_ticket(group, disease, touchstone, scenario,
                           report, version, None, yt, config)
 
         def error_callback(report, error):
-            create_ticket(group, disease, touchstone,
+            create_ticket(group, disease, touchstone, scenario,
                           report, None, error, yt, config)
 
         running_reports_repo = RunningReportsRepository(host=config.host)
@@ -75,7 +75,7 @@ def run_diagnostic_reports(group,
         return {}
 
 
-def create_ticket(group, disease, touchstone,
+def create_ticket(group, disease, touchstone, scenario,
                   report: ReportConfig, version,
                   error,
                   yt: YTClient,
@@ -85,9 +85,11 @@ def create_ticket(group, disease, touchstone,
         summary = "Check & share diag report with {} ({}) {}" if \
             report_success else \
             "Run, check & share diag report with {} ({}) {}"
-        description = get_version_url(report, version, config) if \
+        result = get_version_url(report, version, config) if \
             report_success else \
             "Auto-run failed with error: {}".format(error)
+        description = "Report run triggered by upload to scenario: {}. {}"\
+            .format(scenario, result)
         create_tags(yt, group, disease, touchstone, report)
         query = "tag: {} AND tag: {} AND tag: {} AND tag: {} " \
                 "AND state: Incoming"

--- a/src/task_run_diagnostic_reports.py
+++ b/src/task_run_diagnostic_reports.py
@@ -1,6 +1,9 @@
+import json
+import urllib.parse
 import os
 
-from YTClient.YTDataClasses import Project, Command
+from YTClient.YTDataClasses import Project, Command, Issue
+from YTClient.RequestEngine import RequestType, RequestEngine
 
 from src.utils.run_reports import run_reports
 from datetime import datetime, timedelta
@@ -11,7 +14,7 @@ from urllib.parse import quote as urlencode
 import logging
 from src.orderlyweb_client_wrapper import OrderlyWebClientWrapper
 from src.utils.running_reports_repository import RunningReportsRepository
-from YTClient.YTClient import YTClient
+from YTClient.YTClient import YTClient, YTException
 
 vimc_project_id = "78-0"
 
@@ -85,34 +88,42 @@ def create_ticket(group, disease, touchstone,
         description = get_version_url(report, version, config) if \
             report_success else \
             "Auto-run failed with error: {}".format(error)
-        query = "tag: {} tag: {} tag: {} status: Incoming"
+        create_tags(yt, group, disease, touchstone, report)
+        query = "tag: {} AND tag: {} AND tag: {} AND tag: {} " \
+                "AND state: Incoming"
         existing_issues = yt.get_issues(
-            query.format(disease, touchstone, group),
-            ["id"])
+            query.format(disease, touchstone, group, report.name),
+            ["id", "summary", "description", "tags(name)"])
         summary = summary.format(group, disease, touchstone)
         if len(existing_issues) > 0:
             existing_issue = existing_issues[0]
-            yt.run_command(
-                Command([existing_issue],
-                        "for {} implementer {} summary {} description {}"
-                        .format(
-                            report.assignee,
-                            report.assignee,
-                            summary,
-                            description)))
+            yt.update_issue(existing_issue, summary, description)
         else:
             issue = yt.create_issue(Project(vimc_project_id),
                                     summary,
                                     description)
+            comm = "for {} implementer {} tag {} tag {} tag {} tag {}".format(
+                report.assignee,
+                report.assignee,
+                group, disease,
+                touchstone,
+                report.name)
             yt.run_command(
-                Command([issue],
-                        "for {} implementer {} tag {} tag {} tag {}".format(
-                            report.assignee,
-                            report.assignee,
-                            group, disease,
-                            touchstone)))
+                Command([issue], comm))
     except Exception as ex:
         logging.exception(ex)
+
+
+def create_tags(yt, group, disease, touchstone, report):
+    tags = yt.get_tags(fields=["name"])
+    if len([t for t in tags if t["name"] == disease]) == 0:
+        yt.create_tag(disease)
+    if len([t for t in tags if t["name"] == group]) == 0:
+        yt.create_tag(group)
+    if len([t for t in tags if t["name"] == touchstone]) == 0:
+        yt.create_tag(touchstone)
+    if len([t for t in tags if t["name"] == report.name]) == 0:
+        yt.create_tag(report.name)
 
 
 def send_diagnostic_report_email(emailer,

--- a/test/integration/test_task_run_diagnostic_reports.py
+++ b/test/integration/test_task_run_diagnostic_reports.py
@@ -187,7 +187,7 @@ def test_ticket_created_on_success():
     assert implementer == ("a.hill" if r1 == "diagnostic" else "e.russell")
 
     tags = [i["name"] for i in i1["tags"]]
-    assert len(tags) == 3
+    assert len(tags) == 4
     assert "testGroup" in tags
     assert "testDisease" in tags
     assert yt.test_touchstone in tags
@@ -202,7 +202,7 @@ def test_ticket_created_on_success():
     assert implementer == ("a.hill" if r2 == "diagnostic" else "e.russell")
 
     tags = [i["name"] for i in i2["tags"]]
-    assert len(tags) == 3
+    assert len(tags) == 4
     assert "testGroup" in tags
     assert "testDisease" in tags
     assert yt.test_touchstone in tags
@@ -241,7 +241,7 @@ def test_ticket_created_on_error(mock_orderlyweb_url):
     assert i1["description"] == expected_err
 
     tags = [i["name"] for i in i1["tags"]]
-    assert len(tags) == 3
+    assert len(tags) == 4
     assert "testGroup" in tags
     assert "testDisease" in tags
     assert yt.test_touchstone in tags
@@ -250,7 +250,79 @@ def test_ticket_created_on_error(mock_orderlyweb_url):
     assert i2["description"] == expected_err
 
     tags = [i["name"] for i in i2["tags"]]
-    assert len(tags) == 3
+    assert len(tags) == 4
     assert "testGroup" in tags
     assert "testDisease" in tags
     assert yt.test_touchstone in tags
+
+
+def test_ticket_update_on_success():
+    result = run_diagnostic_reports("testGroup",
+                                    "testDisease",
+                                    yt.test_touchstone,
+                                    "2020-11-01T01:02:03",
+                                    "s1",
+                                    "estimate_uploader@example.com")
+    versions = list(result.keys())
+    issues = yt.get_issues("summary: {}".format(yt.test_touchstone),
+                           fields=["summary",
+                                   "description",
+                                   "tags(name)",
+                                   "customFields(name,value(id,login))"])
+
+    assert len(versions) == 2
+    assert len(issues) == 2
+
+    v1 = versions[0]
+    r1 = result[v1]["report"]
+    i1 = [i for i in issues if v1 in i["description"]][0]
+
+    v2 = versions[1]
+    r2 = result[v2]["report"]
+    i2 = [i for i in issues if v2 in i["description"]][0]
+
+    expected_summary = \
+        "Check & share diag report with testGroup (testDisease) {}" \
+        .format(yt.test_touchstone)
+    expected_link1 = "http://localhost:8888/report/{}/{}/".format(r1, v1)
+    assert i1["summary"] == expected_summary
+    assert i1["description"] == expected_link1
+
+    expected_link2 = "http://localhost:8888/report/{}/{}/".format(r2, v2)
+    assert i2["summary"] == expected_summary
+    assert i2["description"] == expected_link2
+
+    result = run_diagnostic_reports("testGroup",
+                                    "testDisease",
+                                    yt.test_touchstone,
+                                    "2020-11-01T01:02:03",
+                                    "s1",
+                                    "estimate_uploader@example.com")
+    new_versions = list(result.keys())
+    new_issues = yt.get_issues("summary: {}".format(yt.test_touchstone),
+                               fields=["summary",
+                                       "status",
+                                       "description",
+                                       "tags(name)",
+                                       "customFields(name,value(id,login))"])
+
+    assert len(new_issues) == 2
+
+    v1 = new_versions[0]
+    r1 = result[v1]["report"]
+    i1 = [i for i in new_issues if v1 in i["description"]][0]
+
+    v2 = new_versions[1]
+    r2 = result[v2]["report"]
+    i2 = [i for i in new_issues if v2 in i["description"]][0]
+
+    expected_summary = \
+        "Check & share diag report with testGroup (testDisease) {}" \
+        .format(yt.test_touchstone)
+    expected_link1 = "http://localhost:8888/report/{}/{}/".format(r1, v1)
+    assert i1["summary"] == expected_summary
+    assert i1["description"] == expected_link1
+
+    expected_link2 = "http://localhost:8888/report/{}/{}/".format(r2, v2)
+    assert i2["summary"] == expected_summary
+    assert i2["description"] == expected_link2

--- a/test/integration/test_task_run_diagnostic_reports.py
+++ b/test/integration/test_task_run_diagnostic_reports.py
@@ -177,9 +177,10 @@ def test_ticket_created_on_success():
     expected_summary = \
         "Check & share diag report with testGroup (testDisease) {}" \
         .format(yt.test_touchstone)
-    expected_link1 = "http://localhost:8888/report/{}/{}/".format(r1, v1)
+    expected_desc1 = "Report run triggered by upload to scenario: s1. " \
+                     "http://localhost:8888/report/{}/{}/".format(r1, v1)
     assert i1["summary"] == expected_summary
-    assert i1["description"] == expected_link1
+    assert i1["description"] == expected_desc1
     assignee = get_field(i1, "Assignee")
     assert assignee == ("a.hill" if r1 == "diagnostic" else "e.russell")
 
@@ -192,9 +193,10 @@ def test_ticket_created_on_success():
     assert "testDisease" in tags
     assert yt.test_touchstone in tags
 
-    expected_link2 = "http://localhost:8888/report/{}/{}/".format(r2, v2)
+    expected_desc2 = "Report run triggered by upload to scenario: s1. " \
+                     "http://localhost:8888/report/{}/{}/".format(r2, v2)
     assert i2["summary"] == expected_summary
-    assert i2["description"] == expected_link2
+    assert i2["description"] == expected_desc2
     assignee = get_field(i2, "Assignee")
     assert assignee == ("a.hill" if r2 == "diagnostic" else "e.russell")
 
@@ -231,7 +233,8 @@ def test_ticket_created_on_error(mock_orderlyweb_url):
         "Run, check & share diag report with testGroup (testDisease) {}" \
         .format(yt.test_touchstone)
 
-    expected_err = "Auto-run failed with error: " + \
+    expected_err = "Report run triggered by upload to scenario: s1. " \
+                   "Auto-run failed with error: " + \
                    "Orderlyweb authentication failed; could not begin task"
 
     i1 = issues[0]
@@ -284,13 +287,15 @@ def test_ticket_update_on_success():
     expected_summary = \
         "Check & share diag report with testGroup (testDisease) {}" \
         .format(yt.test_touchstone)
-    expected_link1 = "http://localhost:8888/report/{}/{}/".format(r1, v1)
+    expected_desc1 = "Report run triggered by upload to scenario: s1. " \
+                     "http://localhost:8888/report/{}/{}/".format(r1, v1)
     assert i1["summary"] == expected_summary
-    assert i1["description"] == expected_link1
+    assert i1["description"] == expected_desc1
 
-    expected_link2 = "http://localhost:8888/report/{}/{}/".format(r2, v2)
+    expected_desc2 = "Report run triggered by upload to scenario: s1. " \
+                     "http://localhost:8888/report/{}/{}/".format(r2, v2)
     assert i2["summary"] == expected_summary
-    assert i2["description"] == expected_link2
+    assert i2["description"] == expected_desc2
 
     result = run_diagnostic_reports("testGroup",
                                     "testDisease",
@@ -319,10 +324,12 @@ def test_ticket_update_on_success():
     expected_summary = \
         "Check & share diag report with testGroup (testDisease) {}" \
         .format(yt.test_touchstone)
-    expected_link1 = "http://localhost:8888/report/{}/{}/".format(r1, v1)
+    expected_desc1 = "Report run triggered by upload to scenario: s1. " \
+                     "http://localhost:8888/report/{}/{}/".format(r1, v1)
     assert i1["summary"] == expected_summary
-    assert i1["description"] == expected_link1
+    assert i1["description"] == expected_desc1
 
-    expected_link2 = "http://localhost:8888/report/{}/{}/".format(r2, v2)
+    expected_desc2 = "Report run triggered by upload to scenario: s1. " \
+                     "http://localhost:8888/report/{}/{}/".format(r2, v2)
     assert i2["summary"] == expected_summary
-    assert i2["description"] == expected_link2
+    assert i2["description"] == expected_desc2

--- a/test/unit/test_create_ticket.py
+++ b/test/unit/test_create_ticket.py
@@ -20,7 +20,7 @@ def test_tags_created():
     mock_client.create_issue = Mock(return_value="ISSUE")
     mock_client.get_issues = Mock(return_value=[])
     mock_client.get_tags = Mock(return_value=[])
-    create_ticket("g1", "d1", "t1", report, "1234", None,
+    create_ticket("g1", "d1", "t1", "s1", report, "1234", None,
                   mock_client, mock_config)
     mock_client.create_tag.assert_has_calls(
         [call("d1"), call("g1"), call("t1"), call("TEST")])
@@ -34,7 +34,7 @@ def test_tags_not_created_if_exists():
     mock_client.create_issue = Mock(return_value="ISSUE")
     mock_client.get_issues = Mock(return_value=[])
     mock_client.get_tags = Mock(return_value=fake_tags)
-    create_ticket("g1", "d1", "t1", report, "1234", None,
+    create_ticket("g1", "d1", "t1", "s1", report, "1234", None,
                   mock_client, mock_config)
     mock_client.create_tag.assert_has_calls([])
 
@@ -47,10 +47,11 @@ def test_create_ticket_with_version():
     mock_client.create_issue = Mock(return_value="ISSUE")
     mock_client.get_issues = Mock(return_value=[])
     mock_client.get_tags = Mock(return_value=fake_tags)
-    create_ticket("g1", "d1", "t1", report, "1234", None,
+    create_ticket("g1", "d1", "t1", "s1", report, "1234", None,
                   mock_client, mock_config)
     expected_create = call(Project(id="78-0"),
                            "Check & share diag report with g1 (d1) t1",
+                           "Report run triggered by upload to scenario: s1. "
                            "http://orderly-web/report/TEST/1234/")
     mock_client.create_issue.assert_has_calls([expected_create])
     expected_command_query = \
@@ -68,10 +69,11 @@ def test_create_ticket_without_version():
     mock_client.create_issue = Mock(return_value="ISSUE")
     mock_client.get_issues = Mock(return_value=[])
     mock_client.get_tags = Mock(return_value=fake_tags)
-    create_ticket("g1", "d1", "t1", report, None, "Error message",
+    create_ticket("g1", "d1", "t1", "s1", report, None, "Error message",
                   mock_client, mock_config)
     expected_create = call(Project(id="78-0"),
                            "Run, check & share diag report with g1 (d1) t1",
+                           "Report run triggered by upload to scenario: s1. "
                            "Auto-run failed with error: Error message")
     mock_client.create_issue.assert_has_calls([expected_create])
 
@@ -92,7 +94,7 @@ def test_create_ticket_logs_errors(logging):
     mock_client.get_tags = Mock(return_value=fake_tags)
     test_ex = Exception("TEST EX")
     mock_client.create_issue = Mock(side_effect=test_ex)
-    create_ticket("g1", "d1", "t1", report, "1234", None,
+    create_ticket("g1", "d1", "t1", "s1", report, "1234", None,
                   mock_client, mock_config)
     logging.exception.assert_has_calls([call(test_ex)])
 
@@ -104,9 +106,10 @@ def test_update_ticket():
     mock_client = Mock(spec=YTClient("", ""))
     mock_client.get_issues = Mock(return_value=["ISSUE"])
     mock_client.get_tags = Mock(return_value=fake_tags)
-    create_ticket("g1", "d1", "t1", report, "1234", None,
+    create_ticket("g1", "d1", "t1", "s1", report, "1234", None,
                   mock_client, mock_config)
     expected_command = call("ISSUE",
                             "Check & share diag report with g1 (d1) t1",
+                            "Report run triggered by upload to scenario: s1. "
                             "http://orderly-web/report/TEST/1234/")
     mock_client.update_issue.assert_has_calls([expected_command])

--- a/test/unit/test_create_ticket.py
+++ b/test/unit/test_create_ticket.py
@@ -6,6 +6,38 @@ from src.config import ReportConfig, Config
 from unittest.mock import call, Mock, patch
 from test.unit.test_run_reports import MockConfig
 
+fake_tags = [{"name": "g1"},
+             {"name": "d1"},
+             {"name": "t1"},
+             {"name": "TEST"}]
+
+
+def test_tags_created():
+    report = ReportConfig("TEST", {}, ["to@example.com"],
+                          "Hi", 100, "a.ssignee")
+    mock_config: Config = MockConfig()
+    mock_client = Mock(spec=YTClient("", ""))
+    mock_client.create_issue = Mock(return_value="ISSUE")
+    mock_client.get_issues = Mock(return_value=[])
+    mock_client.get_tags = Mock(return_value=[])
+    create_ticket("g1", "d1", "t1", report, "1234", None,
+                  mock_client, mock_config)
+    mock_client.create_tag.assert_has_calls(
+        [call("d1"), call("g1"), call("t1"), call("TEST")])
+
+
+def test_tags_not_created_if_exists():
+    report = ReportConfig("TEST", {}, ["to@example.com"],
+                          "Hi", 100, "a.ssignee")
+    mock_config: Config = MockConfig()
+    mock_client = Mock(spec=YTClient("", ""))
+    mock_client.create_issue = Mock(return_value="ISSUE")
+    mock_client.get_issues = Mock(return_value=[])
+    mock_client.get_tags = Mock(return_value=fake_tags)
+    create_ticket("g1", "d1", "t1", report, "1234", None,
+                  mock_client, mock_config)
+    mock_client.create_tag.assert_has_calls([])
+
 
 def test_create_ticket_with_version():
     report = ReportConfig("TEST", {}, ["to@example.com"],
@@ -14,6 +46,7 @@ def test_create_ticket_with_version():
     mock_client = Mock(spec=YTClient("", ""))
     mock_client.create_issue = Mock(return_value="ISSUE")
     mock_client.get_issues = Mock(return_value=[])
+    mock_client.get_tags = Mock(return_value=fake_tags)
     create_ticket("g1", "d1", "t1", report, "1234", None,
                   mock_client, mock_config)
     expected_create = call(Project(id="78-0"),
@@ -21,7 +54,7 @@ def test_create_ticket_with_version():
                            "http://orderly-web/report/TEST/1234/")
     mock_client.create_issue.assert_has_calls([expected_create])
     expected_command_query = \
-        "for a.ssignee implementer a.ssignee tag g1 tag d1 tag t1"
+        "for a.ssignee implementer a.ssignee tag g1 tag d1 tag t1 tag TEST"
     expected_command = call(Command(issues=["ISSUE"],
                                     query=expected_command_query))
     mock_client.run_command.assert_has_calls([expected_command])
@@ -34,6 +67,7 @@ def test_create_ticket_without_version():
     mock_client = Mock(spec=YTClient("", ""))
     mock_client.create_issue = Mock(return_value="ISSUE")
     mock_client.get_issues = Mock(return_value=[])
+    mock_client.get_tags = Mock(return_value=fake_tags)
     create_ticket("g1", "d1", "t1", report, None, "Error message",
                   mock_client, mock_config)
     expected_create = call(Project(id="78-0"),
@@ -42,7 +76,7 @@ def test_create_ticket_without_version():
     mock_client.create_issue.assert_has_calls([expected_create])
 
     expected_command_query = \
-        "for a.ssignee implementer a.ssignee tag g1 tag d1 tag t1"
+        "for a.ssignee implementer a.ssignee tag g1 tag d1 tag t1 tag TEST"
     expected_command = call(Command(issues=["ISSUE"],
                                     query=expected_command_query))
     mock_client.run_command.assert_has_calls([expected_command])
@@ -55,6 +89,7 @@ def test_create_ticket_logs_errors(logging):
     mock_config: Config = MockConfig()
     mock_client = Mock(spec=YTClient("", ""))
     mock_client.get_issues = Mock(return_value=[])
+    mock_client.get_tags = Mock(return_value=fake_tags)
     test_ex = Exception("TEST EX")
     mock_client.create_issue = Mock(side_effect=test_ex)
     create_ticket("g1", "d1", "t1", report, "1234", None,
@@ -68,12 +103,10 @@ def test_update_ticket():
     mock_config: Config = MockConfig()
     mock_client = Mock(spec=YTClient("", ""))
     mock_client.get_issues = Mock(return_value=["ISSUE"])
+    mock_client.get_tags = Mock(return_value=fake_tags)
     create_ticket("g1", "d1", "t1", report, "1234", None,
                   mock_client, mock_config)
-    expected_command_query = \
-        "for a.ssignee implementer a.ssignee" \
-        " summary Check & share diag report with g1 (d1) t1" \
-        " description http://orderly-web/report/TEST/1234/"
-    expected_command = call(Command(issues=["ISSUE"],
-                                    query=expected_command_query))
-    mock_client.run_command.assert_has_calls([expected_command])
+    expected_command = call("ISSUE",
+                            "Check & share diag report with g1 (d1) t1",
+                            "http://orderly-web/report/TEST/1234/")
+    mock_client.update_issue.assert_has_calls([expected_command])


### PR DESCRIPTION
This PR addresses the proliferation of YT tickets for the same diagnostic report parameter group. 

On report completion, check whether an "Incoming" ticket exists for the given report/group/disease/touchstone, and update with the new report url (or error message) if so. Otherwise create a new ticket.