### PR TITLE
vimc-6327 Celery worker can access burden_estimates_file folder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,20 @@
 FROM python:3.6
 
+RUN adduser --disabled-login  worker
+USER worker
 
 WORKDIR /home/worker
-COPY requirements.txt ./
-RUN pip install --no-cache-dir -r ./requirements.txt && \
+COPY --chown=worker:worker requirements.txt ./
+RUN pip install --user --no-cache-dir -r ./requirements.txt && \
         rm ./requirements.txt
 
-ENV PATH="/home/root/.local/bin:${PATH}"
+ENV PATH="/home/worker/.local/bin:${PATH}"
 
-COPY src ./src
+COPY --chown=worker:worker src ./src
 
-COPY config/docker_config.yml ./config/config.yml
-COPY config/email_templates ./config/email_templates
+COPY --chown=worker:worker config/docker_config.yml ./config/config.yml
+COPY --chown=worker:worker config/email_templates ./config/email_templates
+
+RUN mkdir burden_estimate_files
 
 ENTRYPOINT ["celery", "-A", "src", "worker", "-l", "INFO"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,16 @@
 FROM python:3.6
 
-RUN adduser --disabled-login  worker
-USER worker
 
 WORKDIR /home/worker
-COPY --chown=worker:worker requirements.txt ./
-RUN pip install --user --no-cache-dir -r ./requirements.txt && \
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r ./requirements.txt && \
         rm ./requirements.txt
 
-ENV PATH="/home/worker/.local/bin:${PATH}"
+ENV PATH="/home/root/.local/bin:${PATH}"
 
-COPY --chown=worker:worker src ./src
+COPY src ./src
 
-COPY --chown=worker:worker config/docker_config.yml ./config/config.yml
-COPY --chown=worker:worker config/email_templates ./config/email_templates
+COPY config/docker_config.yml ./config/config.yml
+COPY config/email_templates ./config/email_templates
 
 ENTRYPOINT ["celery", "-A", "src", "worker", "-l", "INFO"]

--- a/scripts/run-docker-worker.sh
+++ b/scripts/run-docker-worker.sh
@@ -8,7 +8,7 @@ ARCHIVE_DIR=test_archive_files
 LOCAL_ARCHIVE_DIR=$HERE/../$ARCHIVE_DIR
 
 rm $LOCAL_ARCHIVE_DIR -rf
-mkdir $LOCAL_ARCHIVE_DIR
+mkdir -m a+rw $LOCAL_ARCHIVE_DIR
 
 docker run --env YOUTRACK_TOKEN=$YOUTRACK_TOKEN \
     --name $NAME \

--- a/scripts/run-docker-worker.sh
+++ b/scripts/run-docker-worker.sh
@@ -8,7 +8,7 @@ ARCHIVE_DIR=test_archive_files
 LOCAL_ARCHIVE_DIR=$HERE/../$ARCHIVE_DIR
 
 rm $LOCAL_ARCHIVE_DIR -rf
-mkdir -m a+rw $LOCAL_ARCHIVE_DIR
+mkdir $LOCAL_ARCHIVE_DIR
 
 docker run --env YOUTRACK_TOKEN=$YOUTRACK_TOKEN \
     --name $NAME \


### PR DESCRIPTION
Create the required `burden_estimates_files` folder for the archive task in the Dockerfile so the worker user has permissions to alter the folder. Corresponding changes to the montagu PR [here](https://github.com/vimc/montagu/pull/221/commits/7abc779a1878dfa48d06b71aba0c79fb87878ab1)