### PR TITLE
vimc-6328 Schedule archive task to run nightly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,3 @@ celerybeat-schedule
 /demo
 /git
 /test_archive_files
-

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea
 .cache
+celerybeat-schedule
 /*/__pycache__/
 /*/*/__pycache__/
 /*/*.pyc
@@ -7,3 +8,4 @@
 /demo
 /git
 /test_archive_files
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,4 @@ COPY --chown=worker:worker config/email_templates ./config/email_templates
 
 RUN mkdir burden_estimate_files
 
-ENTRYPOINT ["celery", "-A", "src", "worker", "-l", "INFO"]
+ENTRYPOINT ["celery", "-A", "src", "worker", "-l", "INFO", "-B"]

--- a/scripts/run-dev-worker.sh
+++ b/scripts/run-dev-worker.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 set -ex
 
-celery -A src worker -l INFO
+# Run worker with beat scheduler
+celery -A src worker -l INFO -B

--- a/src/celery.py
+++ b/src/celery.py
@@ -19,9 +19,9 @@ app.conf.update(
     result_expires=3600,
     timezone='Europe/London',
     beat_schedule={
-        'add-every-20-seconds': {
+        'nightly_archive_task': {
             'task': 'archive_folder_contents',
-            'schedule': crontab(hour=1),
+            'schedule': crontab(hour=10),
             'args': ['burden_estimate_files']
         }
     }

--- a/src/celery.py
+++ b/src/celery.py
@@ -21,7 +21,7 @@ app.conf.update(
     beat_schedule={
         'nightly_archive_task': {
             'task': 'archive_folder_contents',
-            'schedule': crontab(hour=1),
+            'schedule': crontab(hour=1, minute=0),
             'args': ['burden_estimate_files']
         }
     }

--- a/src/celery.py
+++ b/src/celery.py
@@ -1,5 +1,6 @@
 from celery import Celery
 from .config import Config
+from src.task_archive_folder_contents import archive_folder_contents
 
 config = Config()
 redis_db = "redis://{}/0".format(config.host)
@@ -16,7 +17,16 @@ app = Celery('tasks',
 # Optional configuration, see the celery application user guide.
 app.conf.update(
     result_expires=3600,
+    timezone='Europe/London'
 )
+
+
+@app.on_after_configure.connect
+def setup_periodic_tasks(sender):
+    sender.add_periodic_task(
+        crontab(hour=1),
+        archive_folder_contents.s('burden_estimate_files')
+    )
 
 
 if __name__ == '__main__':

--- a/src/celery.py
+++ b/src/celery.py
@@ -21,7 +21,7 @@ app.conf.update(
     beat_schedule={
         'nightly_archive_task': {
             'task': 'archive_folder_contents',
-            'schedule': crontab(hour=10),
+            'schedule': crontab(hour=1),
             'args': ['burden_estimate_files']
         }
     }


### PR DESCRIPTION
This configures the Celery worker to schedule the `archive_folder_contents` task to run nightly, at 1am (local). 

This has been deployed to UAT for a few days - if you look at the docker logs for the task queue container you'll see that it has been running the task each night (at 00:00 UTC):
![image](https://user-images.githubusercontent.com/44669576/173536846-3add3a6f-b6c3-4442-9766-4d75077393f2.png)
It hasn't had any files to remove, but it's logged messages indicating that the task has run. 

