### PR TITLE
vimc-6852_redis_host

### DIFF
--- a/.github/workflows/test-and-push.yml
+++ b/.github/workflows/test-and-push.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: 3.8
 
       - name: Install dependencies
         run: |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,8 @@ services:
     ports:
       - "5555:5555"
     environment:
-      - CELERY_BROKER_URL=redis://guest@montagu_mq_1//
-      - CELERY_RESULT_BACKEND=redis://guest@montagu_mq_1/0
+      - CELERY_BROKER_URL=redis://montagu_mq_1//
+      - CELERY_RESULT_BACKEND=redis://montagu_mq_1/0
       - FLOWER_PORT=5555
   api:
     image: ${REGISTRY}/montagu-api:master

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pyyaml
 montagu>=0.0.2
 orderlyweb-api>=0.0.10
 git+https://github.com/reside-ic/youtrack-rest-python-library
+constellation

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,5 @@ future
 pyyaml
 montagu>=0.0.2
 orderlyweb-api>=0.0.10
-git+https://github.com/reside-ic/youtrack-rest-python-library
+git+https://github.com/reside-ic/youtrack-rest-python-library@enable_ssl_validation
 constellation
-urllib3==1.25.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ montagu>=0.0.2
 orderlyweb-api>=0.0.10
 git+https://github.com/reside-ic/youtrack-rest-python-library
 constellation
+urllib3==1.25.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ future
 pyyaml
 montagu>=0.0.2
 orderlyweb-api>=0.0.10
-git+https://github.com/reside-ic/youtrack-rest-python-library@enable_ssl_validation
+git+https://github.com/reside-ic/youtrack-rest-python-library
 constellation

--- a/test/integration/test_worker.py
+++ b/test/integration/test_worker.py
@@ -10,7 +10,7 @@ from src.orderlyweb_client_wrapper import OrderlyWebClientWrapper
 from test.integration.yt_utils import YouTrackUtils
 from test.integration.file_utils import write_text_file
 
-app = celery.Celery(broker="redis://guest@localhost//", backend="redis://")
+app = celery.Celery(broker="redis://localhost//", backend="redis://")
 reports_sig = "run-diagnostic-reports"
 archive_folder_sig = "archive_folder_contents"
 yt = YouTrackUtils()


### PR DESCRIPTION
Extends the vimc-6852 branch: Updates to allow montagu task queue build - fixes errors resulting from dependency changes
- do not specify `guest@` when connecting to redis
- use constellation
- use version of YTClient which enables ssl validation